### PR TITLE
Feature: add context method to the failed result exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file. This projec
 
 ## Unreleased
 
+### Added
+
+- The `FailedResultException` now implements the `ContextProviderInterface` to get log context from the exception's
+  result object. In Laravel applications, this means the exception context will automatically be logged.
+
+### Changed
+
+- **BREAKING** the `ResultContext` and `ObjectContext` helper classes have been moved to the `Toolkit\Loggable`
+  namespace.
+
 ## [1.1.0] - 2024-03-14
 
 ### Added

--- a/src/Bus/Middleware/LogMessageDispatch.php
+++ b/src/Bus/Middleware/LogMessageDispatch.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\Bus\Middleware;
 
 use Closure;
-use CloudCreativity\Modules\Infrastructure\Log\ObjectContext;
-use CloudCreativity\Modules\Infrastructure\Log\ResultContext;
+use CloudCreativity\Modules\Toolkit\Loggable\ObjectContext;
+use CloudCreativity\Modules\Toolkit\Loggable\ResultContext;
 use CloudCreativity\Modules\Toolkit\Messages\MessageInterface;
 use CloudCreativity\Modules\Toolkit\ModuleBasename;
 use CloudCreativity\Modules\Toolkit\Result\ResultInterface;

--- a/src/EventBus/Middleware/LogInboundIntegrationEvent.php
+++ b/src/EventBus/Middleware/LogInboundIntegrationEvent.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\EventBus\Middleware;
 
 use Closure;
-use CloudCreativity\Modules\Infrastructure\Log\ObjectContext;
+use CloudCreativity\Modules\Toolkit\Loggable\ObjectContext;
 use CloudCreativity\Modules\Toolkit\Messages\IntegrationEventInterface;
 use CloudCreativity\Modules\Toolkit\ModuleBasename;
 use Psr\Log\LoggerInterface;

--- a/src/EventBus/Middleware/LogOutboundIntegrationEvent.php
+++ b/src/EventBus/Middleware/LogOutboundIntegrationEvent.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\EventBus\Middleware;
 
 use Closure;
-use CloudCreativity\Modules\Infrastructure\Log\ObjectContext;
+use CloudCreativity\Modules\Toolkit\Loggable\ObjectContext;
 use CloudCreativity\Modules\Toolkit\Messages\IntegrationEventInterface;
 use CloudCreativity\Modules\Toolkit\ModuleBasename;
 use Psr\Log\LoggerInterface;

--- a/src/Infrastructure/Queue/Middleware/LogPushedToQueue.php
+++ b/src/Infrastructure/Queue/Middleware/LogPushedToQueue.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\Infrastructure\Queue\Middleware;
 
 use Closure;
-use CloudCreativity\Modules\Infrastructure\Log\ObjectContext;
 use CloudCreativity\Modules\Infrastructure\Queue\QueueableInterface;
+use CloudCreativity\Modules\Toolkit\Loggable\ObjectContext;
 use CloudCreativity\Modules\Toolkit\ModuleBasename;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;

--- a/src/Toolkit/Loggable/ObjectContext.php
+++ b/src/Toolkit/Loggable/ObjectContext.php
@@ -9,9 +9,7 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Infrastructure\Log;
-
-use CloudCreativity\Modules\Toolkit\Loggable\ContextProviderInterface;
+namespace CloudCreativity\Modules\Toolkit\Loggable;
 
 final class ObjectContext implements ContextProviderInterface
 {

--- a/src/Toolkit/Loggable/ResultContext.php
+++ b/src/Toolkit/Loggable/ResultContext.php
@@ -9,10 +9,9 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Infrastructure\Log;
+namespace CloudCreativity\Modules\Toolkit\Loggable;
 
 use CloudCreativity\Modules\Toolkit\Identifiers\IdentifierInterface;
-use CloudCreativity\Modules\Toolkit\Loggable\ContextProviderInterface;
 use CloudCreativity\Modules\Toolkit\Result\ErrorInterface;
 use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
 

--- a/src/Toolkit/Result/FailedResultException.php
+++ b/src/Toolkit/Result/FailedResultException.php
@@ -11,10 +11,12 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Toolkit\Result;
 
+use CloudCreativity\Modules\Toolkit\Loggable\ContextProviderInterface;
+use CloudCreativity\Modules\Toolkit\Loggable\ResultContext;
 use RuntimeException;
 use Throwable;
 
-class FailedResultException extends RuntimeException
+class FailedResultException extends RuntimeException implements ContextProviderInterface
 {
     /**
      * FailedResultException constructor.
@@ -36,5 +38,13 @@ class FailedResultException extends RuntimeException
     public function getResult(): ResultInterface
     {
         return $this->result;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function context(): array
+    {
+        return ResultContext::from($this->result)->context();
     }
 }

--- a/tests/Unit/Bus/Middleware/LogMessageDispatchTest.php
+++ b/tests/Unit/Bus/Middleware/LogMessageDispatchTest.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\Tests\Unit\Bus\Middleware;
 
 use CloudCreativity\Modules\Bus\Middleware\LogMessageDispatch;
-use CloudCreativity\Modules\Infrastructure\Log\ObjectContext;
-use CloudCreativity\Modules\Infrastructure\Log\ResultContext;
+use CloudCreativity\Modules\Toolkit\Loggable\ObjectContext;
+use CloudCreativity\Modules\Toolkit\Loggable\ResultContext;
 use CloudCreativity\Modules\Toolkit\Messages\MessageInterface;
 use CloudCreativity\Modules\Toolkit\Result\Result;
 use LogicException;

--- a/tests/Unit/Toolkit/Loggable/ObjectContextTest.php
+++ b/tests/Unit/Toolkit/Loggable/ObjectContextTest.php
@@ -9,10 +9,10 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Log;
+namespace CloudCreativity\Modules\Tests\Unit\Toolkit\Loggable;
 
-use CloudCreativity\Modules\Infrastructure\Log\ObjectContext;
 use CloudCreativity\Modules\Toolkit\Loggable\ContextProviderInterface;
+use CloudCreativity\Modules\Toolkit\Loggable\ObjectContext;
 use PHPUnit\Framework\TestCase;
 
 class ObjectContextTest extends TestCase

--- a/tests/Unit/Toolkit/Loggable/ResultContextTest.php
+++ b/tests/Unit/Toolkit/Loggable/ResultContextTest.php
@@ -9,12 +9,12 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Log;
+namespace CloudCreativity\Modules\Tests\Unit\Toolkit\Loggable;
 
 use BackedEnum;
-use CloudCreativity\Modules\Infrastructure\Log\ResultContext;
 use CloudCreativity\Modules\Toolkit\Identifiers\IdentifierInterface;
 use CloudCreativity\Modules\Toolkit\Loggable\ContextProviderInterface;
+use CloudCreativity\Modules\Toolkit\Loggable\ResultContext;
 use CloudCreativity\Modules\Toolkit\Result\Error;
 use CloudCreativity\Modules\Toolkit\Result\ErrorInterface;
 use CloudCreativity\Modules\Toolkit\Result\Result;

--- a/tests/Unit/Toolkit/Loggable/TestEnum.php
+++ b/tests/Unit/Toolkit/Loggable/TestEnum.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Log;
+namespace CloudCreativity\Modules\Tests\Unit\Toolkit\Loggable;
 
 enum TestEnum: string
 {

--- a/tests/Unit/Toolkit/Result/ErrorTest.php
+++ b/tests/Unit/Toolkit/Result/ErrorTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Tests\Unit\Toolkit\Result;
 
-use CloudCreativity\Modules\Tests\Unit\Infrastructure\Log\TestEnum;
+use CloudCreativity\Modules\Tests\Unit\Toolkit\Loggable\TestEnum;
 use CloudCreativity\Modules\Toolkit\ContractException;
 use CloudCreativity\Modules\Toolkit\Result\Error;
 use CloudCreativity\Modules\Toolkit\Result\ErrorInterface;

--- a/tests/Unit/Toolkit/Result/FailedResultExceptionTest.php
+++ b/tests/Unit/Toolkit/Result/FailedResultExceptionTest.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Tests\Unit\Toolkit\Result;
+
+use CloudCreativity\Modules\Toolkit\Loggable\ContextProviderInterface;
+use CloudCreativity\Modules\Toolkit\Loggable\ResultContext;
+use CloudCreativity\Modules\Toolkit\Result\FailedResultException;
+use CloudCreativity\Modules\Toolkit\Result\Result;
+use PHPUnit\Framework\TestCase;
+
+class FailedResultExceptionTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function test(): void
+    {
+        $result = Result::failed('Something went wrong.')
+            ->withMeta(['foo' => 'bar']);
+
+        $exception = new FailedResultException($result);
+
+        $this->assertSame($result, $exception->getResult());
+        $this->assertSame('Something went wrong.', $exception->getMessage());
+        $this->assertInstanceOf(ContextProviderInterface::class, $exception);
+        $this->assertSame(ResultContext::from($result)->context(), $exception->context());
+    }
+
+    /**
+     * @return void
+     */
+    public function testItHasCodeAndPreviousException(): void
+    {
+        $result = Result::failed('Something went wrong.');
+        $previous = new \LogicException('Boom!');
+
+        $exception = new FailedResultException($result, 99, $previous);
+
+        $this->assertSame($result, $exception->getResult());
+        $this->assertSame('Something went wrong.', $exception->getMessage());
+        $this->assertSame(99, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Unit/Toolkit/Result/ListOfErrorsTest.php
+++ b/tests/Unit/Toolkit/Result/ListOfErrorsTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Tests\Unit\Toolkit\Result;
 
-use CloudCreativity\Modules\Tests\Unit\Infrastructure\Log\TestEnum;
+use CloudCreativity\Modules\Tests\Unit\Toolkit\Loggable\TestEnum;
 use CloudCreativity\Modules\Toolkit\Result\Error;
 use CloudCreativity\Modules\Toolkit\Result\ErrorInterface;
 use CloudCreativity\Modules\Toolkit\Result\KeyedSetOfErrors;

--- a/tests/Unit/Toolkit/Result/ResultTest.php
+++ b/tests/Unit/Toolkit/Result/ResultTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Tests\Unit\Toolkit\Result;
 
-use CloudCreativity\Modules\Tests\Unit\Infrastructure\Log\TestEnum;
+use CloudCreativity\Modules\Tests\Unit\Toolkit\Loggable\TestEnum;
 use CloudCreativity\Modules\Toolkit\ContractException;
 use CloudCreativity\Modules\Toolkit\Result\Error;
 use CloudCreativity\Modules\Toolkit\Result\ListOfErrors;


### PR DESCRIPTION
Added the context method to the failed result exception, by implementing the context provider interface. In Laravel applications, this means the context will be logged with the exception.

To enable this change, the two log context helper classes had to be moved to the toolkit's loggable namespace. This is ok as a change, because they are utility helper classes rather than anything specific to a log implementation. This however makes it a breaking change.