### PR TITLE
Refactor: rename bus middleware interface and improve type-hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ All notable changes to this project will be documented in this file. This projec
 - **BREAKING** The single constructor argument for the `Bus\Validation\CommandValidator`
   and `Bus\Validation\QueryValidator` has been renamed `rules` for clarity. Although breaking, this will only affect
   your implementation if you are using named arguments when constructing either of these validators.
+- **BREAKING** Renamed the bus `MessageMiddlewareInterface` to `BusMiddlewareInterface`. Also changed the type-hint for
+  the message from `MessageInterface` to `CommandInterface|QueryInterface`. This makes this interface clearer about its
+  purpose, as it is intended only for use with commands and queries - i.e. not integration event messages.
 - **BREAKING** the `ResultContext` and `ObjectContext` helper classes have been moved to the `Toolkit\Loggable`
   namespace.
 

--- a/docs/guide/application/commands.md
+++ b/docs/guide/application/commands.md
@@ -199,7 +199,7 @@ use App\Modules\EventManagement\BoundedContext\Application\Commands\{
 use CloudCreativity\Modules\Bus\{
     CommandHandlerContainer,
     Middleware\ExecuteInUnitOfWork,
-    Middleware\LogMessageDispatch,
+    Middleware\LogBusDispatch,
 };
 use CloudCreativity\Modules\Toolkit\Pipeline\PipeContainer;
 
@@ -229,15 +229,15 @@ final class EventManagementApplication implements EventManagementApplicationInte
         );
 
         $middleware->bind(
-            LogMessageDispatch::class,
-            fn () => new LogMessageDispatch(
+            LogBusDispatch::class,
+            fn () => new LogBusDispatch(
                 $this->dependencies->getLogger(),
             ),
         );
 
         /** Attach middleware that runs for all commands */
         $bus->through([
-            LogMessageDispatch::class,
+            LogBusDispatch::class,
         ]);
 
         return $bus;
@@ -468,16 +468,16 @@ Use our `LogMessageDispatch` middleware to log the dispatch of a command, and th
 [PSR Logger](https://php-fig.org/psr/psr-3/).
 
 ```php
-use CloudCreativity\Modules\Bus\Middleware\LogMessageDispatch;
+use CloudCreativity\Modules\Bus\Middleware\LogBusDispatch;
 
 $middleware->bind(
-    LogMessageDispatch::class,
-    fn (): LogMessageDispatch => new LogMessageDispatch(
+    LogBusDispatch::class,
+    fn (): LogBusDispatch => new LogBusDispatch(
         $this->dependencies->getLogger(),
     ),
 );
 
-$bus->through([LogMessageDispatch::class]);
+$bus->through([LogBusDispatch::class]);
 ```
 
 The middleware will log a message before executing the command, with a log level of _debug_. It will then log a message

--- a/docs/guide/application/commands.md
+++ b/docs/guide/application/commands.md
@@ -199,7 +199,7 @@ use App\Modules\EventManagement\BoundedContext\Application\Commands\{
 use CloudCreativity\Modules\Bus\{
     CommandHandlerContainer,
     Middleware\ExecuteInUnitOfWork,
-    Middleware\LogBusDispatch,
+    Middleware\LogMessageDispatch,
 };
 use CloudCreativity\Modules\Toolkit\Pipeline\PipeContainer;
 
@@ -229,15 +229,15 @@ final class EventManagementApplication implements EventManagementApplicationInte
         );
 
         $middleware->bind(
-            LogBusDispatch::class,
-            fn () => new LogBusDispatch(
+            LogMessageDispatch::class,
+            fn () => new LogMessageDispatch(
                 $this->dependencies->getLogger(),
             ),
         );
 
         /** Attach middleware that runs for all commands */
         $bus->through([
-            LogBusDispatch::class,
+            LogMessageDispatch::class,
         ]);
 
         return $bus;
@@ -468,16 +468,16 @@ Use our `LogMessageDispatch` middleware to log the dispatch of a command, and th
 [PSR Logger](https://php-fig.org/psr/psr-3/).
 
 ```php
-use CloudCreativity\Modules\Bus\Middleware\LogBusDispatch;
+use CloudCreativity\Modules\Bus\Middleware\LogMessageDispatch;
 
 $middleware->bind(
-    LogBusDispatch::class,
-    fn (): LogBusDispatch => new LogBusDispatch(
+    LogMessageDispatch::class,
+    fn (): LogMessageDispatch => new LogMessageDispatch(
         $this->dependencies->getLogger(),
     ),
 );
 
-$bus->through([LogBusDispatch::class]);
+$bus->through([LogMessageDispatch::class]);
 ```
 
 The middleware will log a message before executing the command, with a log level of _debug_. It will then log a message

--- a/docs/guide/application/commands.md
+++ b/docs/guide/application/commands.md
@@ -542,10 +542,11 @@ following signature:
 namespace App\Bus\Middleware;
 
 use Closure;
+use CloudCreativity\Modules\Bus\Middleware\CommandMiddlewareInterface;
 use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
 use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
 
-final class MyMiddleware
+final class MyMiddleware implements CommandMiddlewareInterface
 {
     /**
      * Execute the middleware.
@@ -555,7 +556,7 @@ final class MyMiddleware
      * @return ResultInterface<mixed>
      */
     public function __invoke(
-        CommandInterface $command,
+        CommandInterface $command, 
         Closure $next,
     ): ResultInterface
     {
@@ -571,9 +572,44 @@ final class MyMiddleware
 ```
 
 :::tip
-If you're writing middleware that is only meant to be used for a specific command, type-hint that command instead of
-the generic `CommandInterface`.
-
-If you're writing middleware that can be used for both commands and queries, use a union type i.e.
-`CommandInterface|QueryInterface`.
+If you're writing middleware that is only meant to be used for a specific command, do not implement the
+`CommandMiddlewareInterface`. Instead, use the same signature but change the type-hint for the command to the command
+class your middleware is designed to be used with.
 :::
+
+If you want to write middleware that can be used with both commands and queries, implement the `BusMiddlewareInterface`
+instead:
+
+```php
+namespace App\Bus\Middleware;
+
+use Closure;
+use CloudCreativity\Modules\Bus\Middleware\BusMiddlewareInterface;
+use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
+use CloudCreativity\Modules\Toolkit\Messages\QueryInterface;
+use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
+
+class MyBusMiddleware implements BusMiddlewareInterface
+{
+    /**
+     * Handle the command or query.
+     *
+     * @param CommandInterface|QueryInterface $message
+     * @param Closure(CommandInterface|QueryInterface): ResultInterface<mixed> $next
+     * @return ResultInterface<mixed>
+     */
+    public function __invoke(
+        CommandInterface|QueryInterface $message, 
+        Closure $next,
+    ): ResultInterface
+    {
+        // code here executes before the handler
+
+        $result = $next($command);
+
+        // code here executes after the handler
+
+        return $result;
+    }
+}
+```

--- a/docs/guide/application/queries.md
+++ b/docs/guide/application/queries.md
@@ -169,7 +169,7 @@ use App\Modules\EventManagement\BoundedContext\Application\Queries\{
 };
 use CloudCreativity\Modules\Bus\{
     QueryHandlerContainer,
-    Middleware\LogBusDispatch,
+    Middleware\LogMessageDispatch,
 };
 use CloudCreativity\Modules\Toolkit\Pipeline\PipeContainer;
 
@@ -194,15 +194,15 @@ final class EventManagementApplication implements EventManagementApplicationInte
 
         /** Bind middleware factories */
         $middleware->bind(
-            LogBusDispatch::class,
-            fn () => new LogBusDispatch(
+            LogMessageDispatch::class,
+            fn () => new LogMessageDispatch(
                 $this->dependencies->getLogger(),
             ),
         );
 
         /** Attach middleware that runs for all queries */
         $bus->through([
-            LogBusDispatch::class,
+            LogMessageDispatch::class,
         ]);
 
         return $bus;
@@ -351,11 +351,11 @@ Use our `LogMessageDispatch` middleware to log the dispatch of a query, and the 
 [PSR Logger](https://php-fig.org/psr/psr-3/).
 
 ```php
-use CloudCreativity\Modules\Bus\Middleware\LogBusDispatch;
+use CloudCreativity\Modules\Bus\Middleware\LogMessageDispatch;
 
 $middleware->bind(
-    LogBusDispatch::class,
-    fn (): LogBusDispatch => new LogBusDispatch(
+    LogMessageDispatch::class,
+    fn (): LogMessageDispatch => new LogMessageDispatch(
         $this->dependencies->getLogger(),
     ),
 );

--- a/docs/guide/application/queries.md
+++ b/docs/guide/application/queries.md
@@ -376,10 +376,11 @@ following signature:
 namespace App\Bus\Middleware;
 
 use Closure;
+use CloudCreativity\Modules\Bus\Middleware\QueryMiddlewareInterface;
 use CloudCreativity\Modules\Toolkit\Messages\QueryInterface;
 use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
 
-final class MyMiddleware
+final class MyMiddleware implements QueryMiddlewareInterface
 {
     /**
      * Execute the middleware.
@@ -405,9 +406,44 @@ final class MyMiddleware
 ```
 
 :::tip
-If you're writing middleware that is only meant to be used for a specific query, type-hint that query instead of
-the generic `QueryInterface`.
-
-If you're writing middleware that can be used for both commands and queries, use a union type i.e.
-`CommandInterface|QueryInterface`.
+If you're writing middleware that is only meant to be used for a specific query, do not implement the
+`QueryMiddlewareInterface`. Instead, use the same signature but change the type-hint for the query to the query
+class your middleware is designed to be used with.
 :::
+
+If you want to write middleware that can be used with both commands and queries, implement the `BusMiddlewareInterface`
+instead:
+
+```php
+namespace App\Bus\Middleware;
+
+use Closure;
+use CloudCreativity\Modules\Bus\Middleware\BusMiddlewareInterface;
+use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
+use CloudCreativity\Modules\Toolkit\Messages\QueryInterface;
+use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
+
+class MyBusMiddleware implements BusMiddlewareInterface
+{
+    /**
+     * Handle the command or query.
+     *
+     * @param CommandInterface|QueryInterface $message
+     * @param Closure(CommandInterface|QueryInterface): ResultInterface<mixed> $next
+     * @return ResultInterface<mixed>
+     */
+    public function __invoke(
+        CommandInterface|QueryInterface $message, 
+        Closure $next,
+    ): ResultInterface
+    {
+        // code here executes before the handler
+
+        $result = $next($command);
+
+        // code here executes after the handler
+
+        return $result;
+    }
+}
+```

--- a/docs/guide/application/queries.md
+++ b/docs/guide/application/queries.md
@@ -169,7 +169,7 @@ use App\Modules\EventManagement\BoundedContext\Application\Queries\{
 };
 use CloudCreativity\Modules\Bus\{
     QueryHandlerContainer,
-    Middleware\LogMessageDispatch,
+    Middleware\LogBusDispatch,
 };
 use CloudCreativity\Modules\Toolkit\Pipeline\PipeContainer;
 
@@ -194,15 +194,15 @@ final class EventManagementApplication implements EventManagementApplicationInte
 
         /** Bind middleware factories */
         $middleware->bind(
-            LogMessageDispatch::class,
-            fn () => new LogMessageDispatch(
+            LogBusDispatch::class,
+            fn () => new LogBusDispatch(
                 $this->dependencies->getLogger(),
             ),
         );
 
         /** Attach middleware that runs for all queries */
         $bus->through([
-            LogMessageDispatch::class,
+            LogBusDispatch::class,
         ]);
 
         return $bus;
@@ -351,11 +351,11 @@ Use our `LogMessageDispatch` middleware to log the dispatch of a query, and the 
 [PSR Logger](https://php-fig.org/psr/psr-3/).
 
 ```php
-use CloudCreativity\Modules\Bus\Middleware\LogMessageDispatch;
+use CloudCreativity\Modules\Bus\Middleware\LogBusDispatch;
 
 $middleware->bind(
-    LogMessageDispatch::class,
-    fn (): LogMessageDispatch => new LogMessageDispatch(
+    LogBusDispatch::class,
+    fn (): LogBusDispatch => new LogBusDispatch(
         $this->dependencies->getLogger(),
     ),
 );

--- a/src/Bus/Middleware/BusMiddlewareInterface.php
+++ b/src/Bus/Middleware/BusMiddlewareInterface.php
@@ -13,7 +13,6 @@ namespace CloudCreativity\Modules\Bus\Middleware;
 
 use Closure;
 use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
-use CloudCreativity\Modules\Toolkit\Messages\MessageInterface;
 use CloudCreativity\Modules\Toolkit\Messages\QueryInterface;
 use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
 
@@ -23,7 +22,7 @@ interface BusMiddlewareInterface
      * Handle the command or query.
      *
      * @param CommandInterface|QueryInterface $message
-     * @param Closure(MessageInterface): ResultInterface<mixed> $next
+     * @param Closure(CommandInterface|QueryInterface): ResultInterface<mixed> $next
      * @return ResultInterface<mixed>
      */
     public function __invoke(CommandInterface|QueryInterface $message, Closure $next): ResultInterface;

--- a/src/Bus/Middleware/BusMiddlewareInterface.php
+++ b/src/Bus/Middleware/BusMiddlewareInterface.php
@@ -12,17 +12,19 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\Bus\Middleware;
 
 use Closure;
+use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
 use CloudCreativity\Modules\Toolkit\Messages\MessageInterface;
+use CloudCreativity\Modules\Toolkit\Messages\QueryInterface;
 use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
 
-interface MessageMiddlewareInterface
+interface BusMiddlewareInterface
 {
     /**
-     * Handle the message.
+     * Handle the command or query.
      *
-     * @param MessageInterface $message
+     * @param CommandInterface|QueryInterface $message
      * @param Closure(MessageInterface): ResultInterface<mixed> $next
      * @return ResultInterface<mixed>
      */
-    public function __invoke(MessageInterface $message, Closure $next): ResultInterface;
+    public function __invoke(CommandInterface|QueryInterface $message, Closure $next): ResultInterface;
 }

--- a/src/Bus/Middleware/FlushDeferredEvents.php
+++ b/src/Bus/Middleware/FlushDeferredEvents.php
@@ -13,11 +13,12 @@ namespace CloudCreativity\Modules\Bus\Middleware;
 
 use Closure;
 use CloudCreativity\Modules\Infrastructure\DomainEventDispatching\DeferredDispatcherInterface;
-use CloudCreativity\Modules\Toolkit\Messages\MessageInterface;
+use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
+use CloudCreativity\Modules\Toolkit\Messages\QueryInterface;
 use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
 use Throwable;
 
-final class FlushDeferredEvents implements MessageMiddlewareInterface
+final class FlushDeferredEvents implements BusMiddlewareInterface
 {
     /**
      * FlushDeferredEvents constructor.
@@ -31,7 +32,7 @@ final class FlushDeferredEvents implements MessageMiddlewareInterface
     /**
      * @inheritDoc
      */
-    public function __invoke(MessageInterface $message, Closure $next): ResultInterface
+    public function __invoke(CommandInterface|QueryInterface $message, Closure $next): ResultInterface
     {
         try {
             $result = $next($message);

--- a/src/Bus/Middleware/LogBusDispatch.php
+++ b/src/Bus/Middleware/LogBusDispatch.php
@@ -14,13 +14,14 @@ namespace CloudCreativity\Modules\Bus\Middleware;
 use Closure;
 use CloudCreativity\Modules\Toolkit\Loggable\ObjectContext;
 use CloudCreativity\Modules\Toolkit\Loggable\ResultContext;
-use CloudCreativity\Modules\Toolkit\Messages\MessageInterface;
+use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
+use CloudCreativity\Modules\Toolkit\Messages\QueryInterface;
 use CloudCreativity\Modules\Toolkit\ModuleBasename;
 use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
-final class LogMessageDispatch implements MessageMiddlewareInterface
+final class LogBusDispatch implements BusMiddlewareInterface
 {
     /**
      * LogMessageDispatch constructor.
@@ -39,7 +40,7 @@ final class LogMessageDispatch implements MessageMiddlewareInterface
     /**
      * @inheritDoc
      */
-    public function __invoke(MessageInterface $message, Closure $next): ResultInterface
+    public function __invoke(CommandInterface|QueryInterface $message, Closure $next): ResultInterface
     {
         $name = ModuleBasename::tryFrom($message)?->toString() ?? $message::class;
 

--- a/src/Bus/Middleware/LogMessageDispatch.php
+++ b/src/Bus/Middleware/LogMessageDispatch.php
@@ -21,7 +21,7 @@ use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
-final class LogBusDispatch implements BusMiddlewareInterface
+final class LogMessageDispatch implements BusMiddlewareInterface
 {
     /**
      * LogMessageDispatch constructor.

--- a/src/Bus/Middleware/SetupBeforeDispatch.php
+++ b/src/Bus/Middleware/SetupBeforeDispatch.php
@@ -12,10 +12,11 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\Bus\Middleware;
 
 use Closure;
-use CloudCreativity\Modules\Toolkit\Messages\MessageInterface;
+use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
+use CloudCreativity\Modules\Toolkit\Messages\QueryInterface;
 use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
 
-final class SetupBeforeDispatch implements MessageMiddlewareInterface
+final class SetupBeforeDispatch implements BusMiddlewareInterface
 {
     /**
      * SetupBeforeDispatch constructor.
@@ -29,7 +30,7 @@ final class SetupBeforeDispatch implements MessageMiddlewareInterface
     /**
      * @inheritDoc
      */
-    public function __invoke(MessageInterface $message, Closure $next): ResultInterface
+    public function __invoke(CommandInterface|QueryInterface $message, Closure $next): ResultInterface
     {
         $tearDown = ($this->callback)();
 

--- a/src/Bus/Middleware/TearDownAfterDispatch.php
+++ b/src/Bus/Middleware/TearDownAfterDispatch.php
@@ -12,10 +12,11 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\Bus\Middleware;
 
 use Closure;
-use CloudCreativity\Modules\Toolkit\Messages\MessageInterface;
+use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
+use CloudCreativity\Modules\Toolkit\Messages\QueryInterface;
 use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
 
-final class TearDownAfterDispatch implements MessageMiddlewareInterface
+final class TearDownAfterDispatch implements BusMiddlewareInterface
 {
     /**
      * TearDownAfterDispatch constructor.
@@ -29,7 +30,7 @@ final class TearDownAfterDispatch implements MessageMiddlewareInterface
     /**
      * @inheritDoc
      */
-    public function __invoke(MessageInterface $message, Closure $next): ResultInterface
+    public function __invoke(CommandInterface|QueryInterface $message, Closure $next): ResultInterface
     {
         try {
             return $next($message);

--- a/tests/Unit/Bus/Middleware/FlushDeferredEventsTest.php
+++ b/tests/Unit/Bus/Middleware/FlushDeferredEventsTest.php
@@ -13,7 +13,8 @@ namespace CloudCreativity\Modules\Tests\Unit\Bus\Middleware;
 
 use CloudCreativity\Modules\Bus\Middleware\FlushDeferredEvents;
 use CloudCreativity\Modules\Infrastructure\DomainEventDispatching\DeferredDispatcherInterface;
-use CloudCreativity\Modules\Toolkit\Messages\MessageInterface;
+use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
+use CloudCreativity\Modules\Toolkit\Messages\QueryInterface;
 use CloudCreativity\Modules\Toolkit\Result\Result;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -52,7 +53,7 @@ class FlushDeferredEventsTest extends TestCase
      */
     public function testItFlushesDeferredEvents(): void
     {
-        $message = $this->createMock(MessageInterface::class);
+        $message = $this->createMock(CommandInterface::class);
         $expected = Result::ok();
 
         $this->dispatcher
@@ -73,6 +74,7 @@ class FlushDeferredEventsTest extends TestCase
         });
 
         $this->assertSame(['next', 'flush'], $this->sequence);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -80,7 +82,7 @@ class FlushDeferredEventsTest extends TestCase
      */
     public function testItForgetsDeferredEventsOnFailedResult(): void
     {
-        $message = $this->createMock(MessageInterface::class);
+        $message = $this->createMock(QueryInterface::class);
         $expected = Result::failed('Something went wrong.');
 
         $this->dispatcher
@@ -109,7 +111,7 @@ class FlushDeferredEventsTest extends TestCase
      */
     public function testItForgetsDeferredEventsOnException(): void
     {
-        $message = $this->createMock(MessageInterface::class);
+        $message = $this->createMock(CommandInterface::class);
         $expected = new \LogicException('Boom!');
 
         $this->dispatcher

--- a/tests/Unit/Bus/Middleware/LogMessageDispatchTest.php
+++ b/tests/Unit/Bus/Middleware/LogMessageDispatchTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Tests\Unit\Bus\Middleware;
 
-use CloudCreativity\Modules\Bus\Middleware\LogBusDispatch;
+use CloudCreativity\Modules\Bus\Middleware\LogMessageDispatch;
 use CloudCreativity\Modules\Toolkit\Loggable\ObjectContext;
 use CloudCreativity\Modules\Toolkit\Loggable\ResultContext;
 use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
@@ -67,7 +67,7 @@ class LogMessageDispatchTest extends TestCase
                 return true;
             });
 
-        $middleware = new LogBusDispatch($this->logger);
+        $middleware = new LogMessageDispatch($this->logger);
         $actual = $middleware($this->message, function (MessageInterface $received) use ($expected) {
             $this->assertSame($this->message, $received);
             return $expected;
@@ -97,7 +97,7 @@ class LogMessageDispatchTest extends TestCase
                 return true;
             });
 
-        $middleware = new LogBusDispatch($this->logger, LogLevel::NOTICE, LogLevel::WARNING);
+        $middleware = new LogMessageDispatch($this->logger, LogLevel::NOTICE, LogLevel::WARNING);
         $actual = $middleware($this->message, function (MessageInterface $received) use ($expected) {
             $this->assertSame($this->message, $received);
             return $expected;
@@ -124,7 +124,7 @@ class LogMessageDispatchTest extends TestCase
             ->method('log')
             ->with(LogLevel::DEBUG, "Bus dispatching {$name}.", ObjectContext::from($message)->context());
 
-        $middleware = new LogBusDispatch($this->logger);
+        $middleware = new LogMessageDispatch($this->logger);
 
         try {
             $middleware($message, static function () use ($expected) {

--- a/tests/Unit/Bus/Middleware/SetupBeforeDispatchTest.php
+++ b/tests/Unit/Bus/Middleware/SetupBeforeDispatchTest.php
@@ -13,7 +13,8 @@ namespace CloudCreativity\Modules\Tests\Unit\Bus\Middleware;
 
 use Closure;
 use CloudCreativity\Modules\Bus\Middleware\SetupBeforeDispatch;
-use CloudCreativity\Modules\Toolkit\Messages\MessageInterface;
+use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
+use CloudCreativity\Modules\Toolkit\Messages\QueryInterface;
 use CloudCreativity\Modules\Toolkit\Result\Result;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -30,7 +31,7 @@ class SetupBeforeDispatchTest extends TestCase
      */
     public function testItSetsUpAndSucceedsWithoutTeardown(): void
     {
-        $message = $this->createMock(MessageInterface::class);
+        $message = $this->createMock(CommandInterface::class);
         $result = Result::ok();
 
         $middleware = new SetupBeforeDispatch(function () {
@@ -53,7 +54,7 @@ class SetupBeforeDispatchTest extends TestCase
      */
     public function testItSetsUpAndSucceedsWithTeardown(): void
     {
-        $message = $this->createMock(MessageInterface::class);
+        $message = $this->createMock(QueryInterface::class);
         $result = Result::ok();
 
         $middleware = new SetupBeforeDispatch(function (): Closure {
@@ -78,7 +79,7 @@ class SetupBeforeDispatchTest extends TestCase
      */
     public function testItSetsUpAndFailsWithoutTeardown(): void
     {
-        $message = $this->createMock(MessageInterface::class);
+        $message = $this->createMock(CommandInterface::class);
         $result = Result::failed('Something went wrong.');
 
         $middleware = new SetupBeforeDispatch(function () {
@@ -101,7 +102,7 @@ class SetupBeforeDispatchTest extends TestCase
      */
     public function testItSetsUpAndFailsWithTeardown(): void
     {
-        $message = $this->createMock(MessageInterface::class);
+        $message = $this->createMock(CommandInterface::class);
         $result = Result::failed('Something went wrong.');
 
         $middleware = new SetupBeforeDispatch(function (): Closure {
@@ -126,7 +127,7 @@ class SetupBeforeDispatchTest extends TestCase
      */
     public function testItSetsUpAndThrowsExceptionWithoutTeardown(): void
     {
-        $message = $this->createMock(MessageInterface::class);
+        $message = $this->createMock(CommandInterface::class);
         $exception = new RuntimeException('Something went wrong.');
         $actual = null;
 
@@ -155,7 +156,7 @@ class SetupBeforeDispatchTest extends TestCase
      */
     public function testItSetsUpAndThrowsExceptionWithTeardown(): void
     {
-        $message = $this->createMock(MessageInterface::class);
+        $message = $this->createMock(QueryInterface::class);
         $exception = new RuntimeException('Something went wrong.');
         $actual = null;
 

--- a/tests/Unit/Bus/Middleware/TearDownAfterDispatchTest.php
+++ b/tests/Unit/Bus/Middleware/TearDownAfterDispatchTest.php
@@ -12,7 +12,8 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\Tests\Unit\Bus\Middleware;
 
 use CloudCreativity\Modules\Bus\Middleware\TearDownAfterDispatch;
-use CloudCreativity\Modules\Toolkit\Messages\MessageInterface;
+use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
+use CloudCreativity\Modules\Toolkit\Messages\QueryInterface;
 use CloudCreativity\Modules\Toolkit\Result\Result;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -24,7 +25,7 @@ class TearDownAfterDispatchTest extends TestCase
      */
     public function testItInvokesCallbackAfterSuccess(): void
     {
-        $message = $this->createMock(MessageInterface::class);
+        $message = $this->createMock(CommandInterface::class);
         $result = Result::ok();
         $sequence = [];
 
@@ -47,7 +48,7 @@ class TearDownAfterDispatchTest extends TestCase
      */
     public function testItInvokesCallbackAfterFailure(): void
     {
-        $message = $this->createMock(MessageInterface::class);
+        $message = $this->createMock(QueryInterface::class);
         $result = Result::failed('Something went wrong.');
         $sequence = [];
 
@@ -70,7 +71,7 @@ class TearDownAfterDispatchTest extends TestCase
      */
     public function testItInvokesCallbackAfterException(): void
     {
-        $message = $this->createMock(MessageInterface::class);
+        $message = $this->createMock(CommandInterface::class);
         $exception = new RuntimeException('Something went wrong.');
         $actual = null;
         $sequence = [];


### PR DESCRIPTION
Previously the `MessageMiddlewareInterface` type-hinted `MessageInterface`. This was incorrect - because the middleware returns a result, it can only be used with command or query messages, not integration events.

The middleware interface has been renamed `BusMiddlewareInterface` which is more descriptive of its purpose. The message type-hint has been changed from `MessageInterface` to `CommandInterface|QueryInterface`, which again is more accurate.