### PR TITLE
Internal vs external queued work

### DIFF
--- a/docs/guide/application/commands.md
+++ b/docs/guide/application/commands.md
@@ -307,11 +307,15 @@ implementation detail_ of your domain.
 
 ### Queuing Commands
 
-Commands can also be queued by the outside world. To indicate that a command should be queued, the `queue()` method is
-used instead of the `dispatch()` method.
+The `dispatch()` method executes the bounded context's logic immediately via a command handler. Or in other words - 
+commands are dispatched synchronously. But what happens if the presentation and delivery layer does not need to wait 
+for the result of the command being dispatched, and instead wants the command to be handled in a non-blocking way?
 
-This allows the presentation and delivery layer to execute a command in a non-blocking way. For example, our controller
-implementation could be updated to return a `202 Accepted` response to indicate the command has been queued:
+In this scenario, the presentation and delivery layer can choose to queue the command for asynchronous processing. To 
+indicate that a command should be queued, the `queue()` method is used instead of the `dispatch()` method.
+
+This can be used to execute a command in a non-blocking way. For example, our controller implementation could be 
+updated to return a `202 Accepted` response to indicate the command has been queued:
 
 ```php
 namespace App\Http\Controllers\Api\Attendees;
@@ -349,11 +353,9 @@ class CancellationController extends Controller
 }
 ```
 
-:::warning
 To allow commands to be queued, you **must** provide a queue factory to the command bus when creating it. This topic is
 covered in the [Asynchronous Processing](../infrastructure/queues#external-queuing) chapter, with specific examples
 in the _External Queuing_ section.
-:::
 
 ## Middleware
 

--- a/docs/guide/infrastructure/queues.md
+++ b/docs/guide/infrastructure/queues.md
@@ -483,9 +483,9 @@ Extend the generic interface:
 ```php
 namespace App\Modules\EventManagement\BoundedContext\Infrastructure\Queue;
 
-use CloudCreativity\Modules\Infrastructure\Queue\QueueDispatcherInterface;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobDispatcherInterface;
 
-interface EventManagementQueueBusInterface extends QueueDispatcherInterface
+interface EventManagementQueueBusInterface extends QueueJobDispatcherInterface
 {
 }
 ```
@@ -495,9 +495,9 @@ Then create the concrete implementation:
 ```php
 namespace App\Modules\EventManagement\BoundedContext\Infrastructure\Queue;
 
-use CloudCreativity\Modules\Infrastructure\Queue\QueueDispatcher;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobDispatcher;
 
-final class EventManagementQueueBus extends QueueDispatcher implements 
+final class EventManagementQueueBus extends QueueJobDispatcher implements 
     EventManagementQueueBusInterface
 {
 }

--- a/docs/guide/infrastructure/queues.md
+++ b/docs/guide/infrastructure/queues.md
@@ -3,106 +3,43 @@
 Modern PHP frameworks provide implementations that allow you to queue work for asynchronous processing. This is
 advantageous for a number of reasons, including:
 
-1. allowing expensive operations to be executed separately in a non-blocking way, for example allowing an HTTP response
-   to be returned to a client immediately.
+1. allowing expensive and/or long running operations to be executed separately in a non-blocking way, for example
+   allowing an HTTP response to be returned to a client immediately.
 2. providing retry and back-off capabilities when executing work that involves communication with external services -
    e.g. microservices in your architecture and/or third-party applications.
 
 When composing the execution of your bounded context's domain, you should use asynchronous processing to improve both
-the scalability and fault tolerance of your implementation. This package embraces this, by allowing commands to be
-queued for asynchronous execution.
+the scalability and fault tolerance of your implementation. This package embraces this, by providing abstractions that
+allow:
 
-This is achieved via a queue abstraction, that allows you to plug the queuing of commands into any PHP queue
+- command messages to be dispatched by the presentation and delivery layer in a non-blocking way; and
+- work that is internal to the bounded context to be executed asynchronously as queue jobs.
+
+Both use cases are implemented via a queue abstraction, that allows you to plug your bounded context into any PHP queue
 implementation you want to use.
 
-:::tip
-Of the three defined messages - commands, queries and integration events - only commands can be pushed to the queue.
-This is because queued work will mutate the state of the bounded context, i.e. is a "command message" in the CQRS
-pattern followed by this package.
+## Scenarios
 
-If you want to asynchronously publish an integration event, an [Outbox pattern](./outbox-inbox.md) is the best approach.
-:::
+There are two scenarios where a bounded context's work can be queued:
 
-## Queuing Commands
-
-There are two scenarios where commands can be queued:
-
-- **Commands executed as an internal implementation of your bounded context.** A typical example is where a domain event
-  listener queues work that needs to happen as a consequence of the domain event, but the execution of the work does not
-  need to occur immediately. This is a good approach for decomposing potentially long-running or highly complex
-  processes into asynchronously executed steps.
 - **Commands dispatched by the presentation and delivery layer** - but where the presentation layer does not need to
   wait for the result of the command, i.e. prefers to return early. For example, where a HTTP controller action wants to
   dispatch a command but intends to return a `202 Accepted` response rather than waiting for the result. We refer to
-  this as _external queueing_, as the request to queue the command comes from outside your bounded context.
-
-### Internal Queuing
-
-Use domain events to queue work for the bounded context to process asynchronously.
-
-For example, if we needed to recalculate a sales report as a result of an attendee cancelling their ticket. The work is
-a command message, because it will alter the state of the sales report within our bounded context.
-
-A domain event listener would be used in this scenario:
-
-```php
-namespace App\Modules\EventManagement\BoundedContext\Application\Listeners;
-
-use App\Modules\EventManagement\BoundedContext\Application\Commands\RecalculateSalesAtEventCommand;
-use App\Modules\EventManagement\BoundedContext\Domain\Events\AttendeeTicketWasCancelled;
-use CloudCreativity\Modules\Infrastructure\Queue\QueueInterface;
-
-final readonly class QueueTicketSalesReportRecalculation
-{
-    public function __construct(private QueueInterface $queue)
-    {
-    }
-
-    public function handle(AttendeeTicketWasCancelled $event): void
-    {
-        $this->queue->push(new RecalculateSalesAtEventCommand(
-            $event->eventId,
-        ));
-    }
-}
-```
+  this as _external queueing_, as the request to queue the command comes from _outside_ your bounded context.
+- **Work executed as an internal implementation of your bounded context.** A typical example is where a domain event
+  listener queues work that needs to happen as a consequence of the domain event, but the execution of the work does not
+  need to occur immediately. This is a good approach for decomposing potentially long-running or highly complex
+  processes into asynchronously executed steps. We refer to these as _queue jobs_.
 
 :::tip
-Notice the listener is in the application layer. This is because it is combining an application concern (the need to
-alter the state of the bounded context via a command message) with an infrastructure component (the queue abstraction).
+In the CQRS pattern that this package follows, queue jobs are technically _commands_ - because they alter the state of
+your bounded context. However, they are not _command messages_. That's because command messages are concerns of your
+application layer, which means they can be dispatched by the presentation and delivery layer.
+
+Queue jobs in comparison are used for work that is internal to your bounded context, and therefore cannot be
+dispatched by the outside world. They are a concern of your infrastructure layer, and are therefore not _command
+messages_.
 :::
-
-We can also push multiple command messages onto the queue at once. This is useful where a listener may generate multiple
-commands from a single domain event.
-
-For example, imagine our bounded context allows tickets to be transferred between multiple in-person events. When a
-ticket is transferred, we would need to recalculate the sales report for multiple events:
-
-```php
-namespace App\Modules\EventManagement\BoundedContext\Application\Listeners;
-
-use App\Modules\EventManagement\BoundedContext\Application\Commands\RecalculateSalesAtEventCommand;
-use App\Modules\EventManagement\BoundedContext\Domain\Events\TicketsTransferred;
-use CloudCreativity\Modules\Infrastructure\Queue\QueueInterface;
-use CloudCreativity\Modules\Toolkit\Identifiers\IntegerId;
-
-final readonly class QueueReportRecalculationsOnTicketTransfer
-{
-    public function __construct(private QueueInterface $queue)
-    {
-    }
-
-    public function handle(TicketsTransferred $event): void
-    {
-        $commands = array_map(
-            fn (IntegerId $id) => new RecalculateSalesAtEventCommand($id),
-            $event->affectedEventIds,
-        );
-        
-        $this->queue->push($commands);
-    }
-}
-```
 
 ### External Queuing
 
@@ -110,7 +47,7 @@ Commands define the use-cases of your module - specifically, the use-cases where
 of the bounded context. They are part of your bounded context's application interface, and therefore can be dispatched
 by the presentation and delivery layer.
 
-It is reasonable for there to be scenarios where the presentation and delivery later intends to change the state of the
+It is reasonable for there to be scenarios where the presentation and delivery intends to change the state of the
 bounded context via a command, but does not need to wait for the result of that change. Our command bus implementation
 allows this to be signalled by exposing a `queue()` method on the command dispatcher. This allows the outside world to
 signal an intent to alter the state of the bounded context asynchronously.
@@ -174,7 +111,7 @@ final class EventManagementApplication implements EventManagementApplicationInte
         $bus = new EventManagementCommandBus(
             handlers: $handlers = new CommandHandlerContainer(),
             middleware: $middleware = new PipeContainer(),
-            queue: fn () => $this->getQueue(),
+            queue: fn () => $this->getCommandQueue(),
         );
 
         // ...bind command handlers
@@ -183,7 +120,7 @@ final class EventManagementApplication implements EventManagementApplicationInte
         return $bus;
     }
     
-    private function getQueue(): QueueInterface
+    private function getCommandQueue(): QueueInterface
     {
         // ...create a queue, more detail below.
     }
@@ -195,82 +132,140 @@ The command bus requires a closure factory for the queue, so that the queue inst
 of creating the queue is avoided if the `queue()` method is not invoked on the command bus.
 :::
 
+### Internal Queuing
+
+There are many scenarios where it can be advantageous for your bounded context to queue internal work for asynchronous
+processing. We refer to these pieces of work as _queue jobs_. In the CQRS pattern, they are commands as they alter the
+state of your bounded context. But they are a concern of the infrastructure layer that is not exposed to the outside
+world - unlike _command messages_ in your application layer.
+
+Some examples of where a bounded context might need to push internal work to a queue include:
+
+1. Work that needs to occur as a result of a domain event - but does not need to happen in the same unit of work in
+   which that event was emitted and is advantageous to occur separately (e.g. with back-off and retry capabilities).
+2. Splitting expensive or long-running processes into multiple asynchronous jobs that are more memory efficient or
+   individually run for shorter periods of time.
+3. Implementing parallel processing of a task - for example, by splitting a task into multiple jobs that can run
+   concurrently.
+
+Or anything else that fits with the specific use-case of your bounded context!
+
+As an example, say we needed to recalculate a sales report as a result of an attendee cancelling their ticket. If it
+did not need to happen immediately (i.e. within the same unit of work as the event occurs) then we could push it to a
+queue via a domain event listener:
+
+```php
+namespace App\Modules\EventManagement\BoundedContext\Infrastructure\DomainEventListeners;
+
+use App\Modules\EventManagement\BoundedContext\Domain\Events\AttendeeTicketWasCancelled;
+use App\Modules\EventManagement\BoundedContext\Infrastructure\Queue\{
+    RecalculateSalesAtEvent\RecalculateSalesAtEventJob
+};
+use CloudCreativity\Modules\Infrastructure\Queue\QueueInterface;
+
+final readonly class QueueTicketSalesReportRecalculation
+{
+    public function __construct(private QueueInterface $queue)
+    {
+    }
+
+    public function handle(AttendeeTicketWasCancelled $event): void
+    {
+        $this->queue->push(new RecalculateSalesAtEventJob(
+            $event->eventId,
+        ));
+    }
+}
+```
+
 ## Queue
 
-This package provides a queue abstraction that allows you to use any PHP queue implementation. The interface is:
+This package provides a queue abstraction that allows you to use any PHP queue implementation when queuing command
+messages or queue jobs. The interface is:
 
 ```php
 namespace CloudCreativity\Modules\Infrastructure\Queue;
 
 use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
 
 interface QueueInterface
 {
     /**
-     * Push a command or commands onto the queue.
+     * Push a command or queue job onto thw queue.
      *
-     * @param CommandInterface|iterable<CommandInterface> $command
+     * @param CommandInterface|QueueJobInterface $queueable
      * @return void
      */
-    public function push(CommandInterface|iterable $queueable): void;
+    public function push(CommandInterface|QueueJobInterface $queueable): void;
 }
 ```
 
-No other functionality is required. As all queued messages are commands, when your PHP implementation pulls them out of
-the queue it simply needs to dispatch them to your bounded context's command bus.
+This abstraction allows you to push command messages or queue jobs onto a queue. When pulling them from the queue
+for processing, you should either:
 
-This abstraction will work with any PHP queue implementation you wish to use. Below there is a Laravel example.
+1. dispatch command messages to your bounded context's application command bus - as described in
+   the [Commands chapter](../application/commands); or
+2. dispatch queue jobs to the queue dispatcher, as described below in this chapter.
 
-We provide two concrete classes that allow you to wire a queue together with your PHP implementation. If neither of
-these work for you, you can instead write a queue that implements the above interface.
+This abstraction will work with any PHP queue implementation you wish to use. Both of these dispatching patterns
+are shown later in this chapter in a Laravel example.
+
+We provide two concrete classes that allow you to push work onto a queue via your preferred PHP implementation. If 
+neither of these work for you, you can instead write a queue that implements the above interface.
 
 ### Closure Queuing
 
-Our `ClosureQueue` allows you to register closures that handle pushing commands onto your queue. This is useful where
+Our `ClosureQueue` allows you to register closures that handle pushing work onto your queue. This is useful where
 wiring in a queue implementation is extremely simple - as is the case with our Laravel example below.
 
 Create a closure-based queue by providing it with the default closure for queuing commands. For example:
 
 ```php
 use App\Modules\EventManagement\BoundedContext\Application\Queue\DispatchCommandJob;
+use App\Modules\EventManagement\BoundedContext\Infrastructure\Queue\DispatchQueueJob;
 use CloudCreativity\Modules\Infrastructure\Queue\ClosureQueue;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
 use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
 
+// for the queue injected into your command bus
 $queue = new ClosureQueue(
     fn: function (CommandInterface $command): void {
         DispatchCommandJob::dispatch($command);    
+    },
+);
+
+// or a queue for queue jobs
+$queue = new ClosureQueue(
+    fn: function (QueueJobInterface $job): void {
+        DispatchQueueJob::dispatch($job);    
     },
 );
 ```
 
-This closure will be used for all commands, unless you register closures for a specific command. For example:
+This default closure will be used for all commands or queue jobs, unless you register closures for a specific command
+or job. For example:
 
 ```php
 $queue = new ClosureQueue(
-    fn: function (CommandInterface $command): void {
-        DispatchCommandJob::dispatch($command);    
+    fn: function (QueueJobInterface $job): void {
+        DispatchQueueJob::dispatch($job);    
     },
 );
 
 $queue->bind(
-    RecalculateSalesAtEventCommand::class,
-    function (RecalculateSalesAtEventCommand $command): void {
-        DispatchCommandJob::dispatch($command)
+    RecalculateSalesAtEventJob::class,
+    function (RecalculateSalesAtEventJob $job): void {
+        DispatchQueueJob::dispatch($job)
             ->onQueue('reporting');    
     },
 );
 ```
 
-The closure-based queue can also be configured with [middleware](#middleware) as described later in the chapter. For
-example:
+The closure-based queue can also be configured with [queue middleware](#queue-middleware) as described later in the
+chapter. For example:
 
 ```php
-use App\Modules\EventManagement\BoundedContext\Application\Queue\DispatchCommandJob;
-use CloudCreativity\Modules\Infrastructure\Queue\ClosureQueue;
-use CloudCreativity\Modules\Infrastructure\Queue\Middleware\LogPushedToQueue;
-use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
-use CloudCreativity\Modules\Toolkit\Pipeline\PipeContainer;
-
 $queue = new ClosureQueue(
     fn: function (CommandInterface $command): void {
         DispatchCommandJob::dispatch($command);    
@@ -289,7 +284,7 @@ $queue->through([LogPushedToQueue::class]);
 ### Class-Based Queuing
 
 Our `ComponentQueue` allows you to use define queuing logic on classes. Each class is an _enqueuer_ - a component that
-handles pushing an item (in this case a command message) onto a queue.
+handles pushing an item (in this case a command message or queue job) onto a queue.
 
 This is useful in scenarios where you want to use constructor dependency injection when integrating with your PHP
 queue implementation. Or alternatively, if wiring into your implementation is more complex than can be defined in a
@@ -299,7 +294,7 @@ Create this queue as follows:
 
 ```php
 use CloudCreativity\Modules\Infrastructure\Queue\ComponentQueue;
-use CloudCreativity\Modules\Infrastructure\Queue\EnqueuerContainer;
+use CloudCreativity\Modules\Infrastructure\Queue\Enqueuers\EnqueuerContainer;
 
 $queue = new ComponentQueue(
     enqueuers: new EnqueuerContainer(
@@ -309,7 +304,7 @@ $queue = new ComponentQueue(
 ```
 
 The closure provided to the `EnqueuerContainer` constructor is the default enqueuer factory that will be used for all
-commands. You can bind alternative enqueuers for specific commands as follows:
+work that is being queued. You can bind alternative enqueuers for specific commands or queue jobs as follows:
 
 ```php
 $queue = new ComponentQueue(
@@ -319,20 +314,21 @@ $queue = new ComponentQueue(
 );
 
 $enqueuers->bind(
-    RecalculateSalesAtEventCommand::class,
+    RecalculateSalesAtEventJob::class,
     fn () => new ReportingEnqueuer(),
 );
 ```
 
-The enqueuer class can be implemented as you need, but must have a `push()` method that queues the given command. For
-example:
+The enqueuer class can be implemented as you need, but must have a `push()` method that queues the given command
+or queue job. For example:
 
 ```php
-use App\Modules\EventManagement\BoundedContext\Application\Queue;
+use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
 
 class DefaultEnqueuer
 {
-    public function push(CommandInterface $command): void
+    public function push(CommandInterface|QueueJobInterface $queueable): void
     {
         // ...implementation
     }
@@ -340,7 +336,7 @@ class DefaultEnqueuer
 
 class ReportingEnqueuer
 {
-    public function push(RecalculateSalesAtEventCommand $command): void
+    public function push(RecalculateSalesAtEventJob $job): void
     {
         // ...implementation
     }
@@ -348,12 +344,16 @@ class ReportingEnqueuer
 ```
 
 :::tip
-Enqueuers are intentionally in the application layer. This is because they are coordinating an application concern
-(the command message) with an infrastructure component (your PHP queue implementation).
+Enqueuers that are type-hinting specific command messages must be in the application layer. This is because they are
+coordinating an application concern (the command message) with an infrastructure component (your PHP queue
+implementation).
+
+Enqueuers that type-hint specific queue jobs can be in the infrastructure layer, because queue jobs are an
+infrastructure concern (internal to your bounded context).
 :::
 
-The closure-based queue can also be configured with [middleware](#middleware) as described later in the chapter. For
-example:
+The class-based queue can also be configured with [queue middleware](#queue-middleware) as described later in the
+chapter. For example:
 
 ```php
 $queue = new ComponentQueue(
@@ -370,6 +370,12 @@ $middleware->bind(
 
 $queue->through([LogPushedToQueue::class]);
 ```
+
+## Queue Bus
+
+### Creating a Queue Bus
+
+### Dispatching Queue Jobs
 
 ## Laravel Example
 
@@ -501,7 +507,7 @@ $queue->bind(
 );
 ```
 
-## Middleware
+## Queue Middleware
 
 Our queue implementations give you complete control over how to compose the queuing of commands, via middleware.
 Middleware is a powerful way to add cross-cutting concerns to your queue, such as logging.
@@ -583,3 +589,5 @@ final class MyQueueMiddleware
     }
 }
 ```
+
+## Job Middleware

--- a/docs/guide/infrastructure/queues.md
+++ b/docs/guide/infrastructure/queues.md
@@ -424,7 +424,7 @@ interface RecalculateSalesAtEventHandlerInterface
      * @param RecalculateSalesAtEventJob $job
      * @return ResultInterface<null>
      */
-    public function handle(RecalculateSalesAtEventJob $job): ResultInterface;
+    public function execute(RecalculateSalesAtEventJob $job): ResultInterface;
 }
 ```
 
@@ -446,7 +446,7 @@ final readonly class RecalculateSalesAtEventHandler implements
     {
     }
 
-    public function handle(RecalculateSalesAtEventJob $job): Result
+    public function execute(RecalculateSalesAtEventJob $job): Result
     {
         $report = $this->repository->findOrCreate($job->eventId);
         

--- a/src/Bus/CommandDispatcher.php
+++ b/src/Bus/CommandDispatcher.php
@@ -81,7 +81,7 @@ class CommandDispatcher implements CommandDispatcherInterface
     /**
      * @inheritDoc
      */
-    public function queue(CommandInterface|iterable $command): void
+    public function queue(CommandInterface $command): void
     {
         if ($this->queue === null) {
             throw new RuntimeException(

--- a/src/Bus/CommandDispatcherInterface.php
+++ b/src/Bus/CommandDispatcherInterface.php
@@ -27,8 +27,8 @@ interface CommandDispatcherInterface
     /**
      * Queue a command or commands for asynchronous dispatching.
      *
-     * @param CommandInterface|iterable<CommandInterface> $command
+     * @param CommandInterface $command
      * @return void
      */
-    public function queue(CommandInterface|iterable $command): void;
+    public function queue(CommandInterface $command): void;
 }

--- a/src/Infrastructure/Queue/ClosureQueue.php
+++ b/src/Infrastructure/Queue/ClosureQueue.php
@@ -25,7 +25,7 @@ final class ClosureQueue implements QueueInterface
     private array $bindings = [];
 
     /**
-     * @var array<string|callable>
+     * @var list<string|callable>
      */
     private array $pipes = [];
 
@@ -55,7 +55,7 @@ final class ClosureQueue implements QueueInterface
     /**
      * Queue messages through the provided pipes.
      *
-     * @param array<string|callable> $pipes
+     * @param list<string|callable> $pipes
      * @return void
      */
     public function through(array $pipes): void

--- a/src/Infrastructure/Queue/ClosureQueue.php
+++ b/src/Infrastructure/Queue/ClosureQueue.php
@@ -32,7 +32,7 @@ final class ClosureQueue implements QueueInterface
     /**
      * ClosureEnqueuer constructor.
      *
-     * @param Closure(CommandInterface): void $fn
+     * @param Closure $fn
      */
     public function __construct(
         private readonly Closure $fn,
@@ -66,17 +66,14 @@ final class ClosureQueue implements QueueInterface
     /**
      * @inheritDoc
      */
-    public function push(CommandInterface|iterable $command): void
+    public function push(CommandInterface|QueueJobInterface $queueable): void
     {
-        $commands = ($command instanceof CommandInterface) ? [$command] : $command;
+        $enqueuer = $this->bindings[$queueable::class] ?? $this->fn;
 
-        $builder = PipelineBuilder::make($this->middleware)
-            ->through($this->pipes);
+        $pipeline = PipelineBuilder::make($this->middleware)
+            ->through($this->pipes)
+            ->build(new MiddlewareProcessor($enqueuer));
 
-        foreach ($commands as $cmd) {
-            $enqueuer = $this->bindings[$cmd::class] ?? $this->fn;
-            $pipeline = $builder->build(new MiddlewareProcessor($enqueuer));
-            $pipeline->process($cmd);
-        }
+        $pipeline->process($queueable);
     }
 }

--- a/src/Infrastructure/Queue/DispatchThroughMiddleware.php
+++ b/src/Infrastructure/Queue/DispatchThroughMiddleware.php
@@ -11,15 +11,12 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Infrastructure\Queue;
 
-use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
-
-interface QueueInterface
+interface DispatchThroughMiddleware
 {
     /**
-     * Push a command or queue job onto the queue.
+     * Get the middleware to dispatch the queue job through.
      *
-     * @param CommandInterface|QueueJobInterface $queueable
-     * @return void
+     * @return list<callable|string>
      */
-    public function push(CommandInterface|QueueJobInterface $queueable): void;
+    public function middleware(): array;
 }

--- a/src/Infrastructure/Queue/Enqueuers/Enqueuer.php
+++ b/src/Infrastructure/Queue/Enqueuers/Enqueuer.php
@@ -9,8 +9,9 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Infrastructure\Queue;
+namespace CloudCreativity\Modules\Infrastructure\Queue\Enqueuers;
 
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
 use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
 
 final class Enqueuer implements EnqueuerInterface
@@ -27,14 +28,14 @@ final class Enqueuer implements EnqueuerInterface
     /**
      * @inheritDoc
      */
-    public function __invoke(CommandInterface $command): void
+    public function __invoke(CommandInterface|QueueJobInterface $queueable): void
     {
         assert(method_exists($this->enqueuer, 'push'), sprintf(
             'Cannot queue "%s" - enqueuer "%s" does not have a push method.',
-            $command::class,
+            $queueable::class,
             $this->enqueuer::class,
         ));
 
-        $this->enqueuer->push($command);
+        $this->enqueuer->push($queueable);
     }
 }

--- a/src/Infrastructure/Queue/Enqueuers/EnqueuerContainer.php
+++ b/src/Infrastructure/Queue/Enqueuers/EnqueuerContainer.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Infrastructure\Queue;
+namespace CloudCreativity\Modules\Infrastructure\Queue\Enqueuers;
 
 use Closure;
 
@@ -42,13 +42,13 @@ final class EnqueuerContainer implements EnqueuerContainerInterface
     /**
      * @inheritDoc
      */
-    public function get(string $command): EnqueuerInterface
+    public function get(string $queueable): EnqueuerInterface
     {
-        $factory = $this->bindings[$command] ?? $this->default;
+        $factory = $this->bindings[$queueable] ?? $this->default;
 
         $enqueuer = $factory();
 
-        assert(is_object($enqueuer), "Enqueuer binding for {$command} must return an object.");
+        assert(is_object($enqueuer), "Enqueuer binding for {$queueable} must return an object.");
 
         return new Enqueuer($enqueuer);
     }

--- a/src/Infrastructure/Queue/Enqueuers/EnqueuerContainer.php
+++ b/src/Infrastructure/Queue/Enqueuers/EnqueuerContainer.php
@@ -16,7 +16,7 @@ use Closure;
 final class EnqueuerContainer implements EnqueuerContainerInterface
 {
     /**
-     * @var array<string,Closure>
+     * @var array<string, Closure>
      */
     private array $bindings = [];
 

--- a/src/Infrastructure/Queue/Enqueuers/EnqueuerContainerInterface.php
+++ b/src/Infrastructure/Queue/Enqueuers/EnqueuerContainerInterface.php
@@ -9,19 +9,18 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue;
+namespace CloudCreativity\Modules\Infrastructure\Queue\Enqueuers;
 
 use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
 use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
 
-class TestEnqueuer
+interface EnqueuerContainerInterface
 {
     /**
-     * @param CommandInterface|QueueJobInterface $queueable
-     * @return void
+     * Get an enqueuer for the provided command.
+     *
+     * @param class-string<CommandInterface|QueueJobInterface> $queueable
+     * @return EnqueuerInterface
      */
-    public function push(CommandInterface|QueueJobInterface $queueable): void
-    {
-        // no-op
-    }
+    public function get(string $queueable): EnqueuerInterface;
 }

--- a/src/Infrastructure/Queue/Enqueuers/EnqueuerInterface.php
+++ b/src/Infrastructure/Queue/Enqueuers/EnqueuerInterface.php
@@ -9,17 +9,18 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Infrastructure\Queue;
+namespace CloudCreativity\Modules\Infrastructure\Queue\Enqueuers;
 
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
 use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
 
 interface EnqueuerInterface
 {
     /**
-     * Put the command on the queue.
+     * Put the command or queue job on the queue.
      *
-     * @param CommandInterface $command
+     * @param CommandInterface|QueueJobInterface $queueable
      * @return void
      */
-    public function __invoke(CommandInterface $command): void;
+    public function __invoke(CommandInterface|QueueJobInterface $queueable): void;
 }

--- a/src/Infrastructure/Queue/Middleware/ExecuteInUnitOfWork.php
+++ b/src/Infrastructure/Queue/Middleware/ExecuteInUnitOfWork.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Infrastructure\Queue\Middleware;
+
+use Closure;
+use CloudCreativity\Modules\Infrastructure\Persistence\AbortOnFailureException;
+use CloudCreativity\Modules\Infrastructure\Persistence\UnitOfWorkManagerInterface;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
+use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
+
+final class ExecuteInUnitOfWork implements JobMiddlewareInterface
+{
+    /**
+     * ExecuteInUnitOfWork constructor.
+     *
+     * @param UnitOfWorkManagerInterface $unitOfWorkManager
+     * @param int $attempts
+     */
+    public function __construct(
+        private readonly UnitOfWorkManagerInterface $unitOfWorkManager,
+        private readonly int $attempts = 1,
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(QueueJobInterface $job, Closure $next): ResultInterface
+    {
+        try {
+            return $this->unitOfWorkManager->execute(
+                static function () use ($job, $next): ResultInterface {
+                    $res = $next($job);
+                    return $res->didSucceed() ? $res : throw new AbortOnFailureException($res);
+                },
+                $this->attempts,
+            );
+        } catch (AbortOnFailureException $ex) {
+            return $ex->getResult();
+        }
+    }
+}

--- a/src/Infrastructure/Queue/Middleware/FlushDeferredEvents.php
+++ b/src/Infrastructure/Queue/Middleware/FlushDeferredEvents.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Infrastructure\Queue\Middleware;
+
+use Closure;
+use CloudCreativity\Modules\Infrastructure\DomainEventDispatching\DeferredDispatcherInterface;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
+use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
+use Throwable;
+
+final class FlushDeferredEvents implements JobMiddlewareInterface
+{
+    /**
+     * FlushDeferredEvents constructor.
+     *
+     * @param DeferredDispatcherInterface $dispatcher
+     */
+    public function __construct(private readonly DeferredDispatcherInterface $dispatcher)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(QueueJobInterface $job, Closure $next): ResultInterface
+    {
+        try {
+            $result = $next($job);
+        } catch (Throwable $ex) {
+            $this->dispatcher->forget();
+            throw $ex;
+        }
+
+        if ($result->didSucceed()) {
+            $this->dispatcher->flush();
+        } else {
+            $this->dispatcher->forget();
+        }
+
+        return $result;
+    }
+}

--- a/src/Infrastructure/Queue/Middleware/JobMiddlewareInterface.php
+++ b/src/Infrastructure/Queue/Middleware/JobMiddlewareInterface.php
@@ -13,16 +13,16 @@ namespace CloudCreativity\Modules\Infrastructure\Queue\Middleware;
 
 use Closure;
 use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
-use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
+use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
 
-interface QueueMiddlewareInterface
+interface JobMiddlewareInterface
 {
     /**
-     * Handle the command being queued.
+     * Handle the queue job.
      *
-     * @param CommandInterface|QueueJobInterface $queueable
-     * @param Closure(CommandInterface|QueueJobInterface): void $next
-     * @return void
+     * @param QueueJobInterface $queueable
+     * @param Closure(QueueJobInterface): ResultInterface<mixed> $next
+     * @return ResultInterface<mixed>
      */
-    public function __invoke(CommandInterface|QueueJobInterface $queueable, Closure $next): void;
+    public function __invoke(QueueJobInterface $queueable, Closure $next): ResultInterface;
 }

--- a/src/Infrastructure/Queue/Middleware/LogJobDispatch.php
+++ b/src/Infrastructure/Queue/Middleware/LogJobDispatch.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Infrastructure\Queue\Middleware;
+
+use Closure;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
+use CloudCreativity\Modules\Toolkit\Loggable\ObjectContext;
+use CloudCreativity\Modules\Toolkit\Loggable\ResultContext;
+use CloudCreativity\Modules\Toolkit\ModuleBasename;
+use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+final class LogJobDispatch implements JobMiddlewareInterface
+{
+    /**
+     * LogJobDispatch constructor.
+     *
+     * @param LoggerInterface $logger
+     * @param string $dispatchLevel
+     * @param string $dispatchedLevel
+     */
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly string $dispatchLevel = LogLevel::DEBUG,
+        private readonly string $dispatchedLevel = LogLevel::INFO,
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(QueueJobInterface $job, Closure $next): ResultInterface
+    {
+        $name = ModuleBasename::tryFrom($job)?->toString() ?? $job::class;
+
+        $this->logger->log(
+            $this->dispatchLevel,
+            "Queue bus dispatching {$name}.",
+            ObjectContext::from($job)->context(),
+        );
+
+        /** @var ResultInterface<mixed> $result */
+        $result = $next($job);
+
+        $this->logger->log(
+            $this->dispatchedLevel,
+            "Queue bus dispatched {$name}.",
+            ResultContext::from($result)->context(),
+        );
+
+        return $result;
+    }
+}

--- a/src/Infrastructure/Queue/Middleware/LogPushedToQueue.php
+++ b/src/Infrastructure/Queue/Middleware/LogPushedToQueue.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\Infrastructure\Queue\Middleware;
 
 use Closure;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
 use CloudCreativity\Modules\Toolkit\Loggable\ObjectContext;
 use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
 use CloudCreativity\Modules\Toolkit\ModuleBasename;
@@ -37,17 +38,17 @@ final class LogPushedToQueue implements QueueMiddlewareInterface
     /**
      * @inheritDoc
      */
-    public function __invoke(CommandInterface $command, Closure $next): void
+    public function __invoke(CommandInterface|QueueJobInterface $queueable, Closure $next): void
     {
-        $name = ModuleBasename::tryFrom($command)?->toString() ?? $command::class;
+        $name = ModuleBasename::tryFrom($queueable)?->toString() ?? $queueable::class;
 
         $this->log->log(
             $this->queueLevel,
             "Queuing command {$name}.",
-            $context = ObjectContext::from($command)->context(),
+            $context = ObjectContext::from($queueable)->context(),
         );
 
-        $next($command);
+        $next($queueable);
 
         $this->log->log($this->queuedLevel, "Queued command {$name}.", $context);
     }

--- a/src/Infrastructure/Queue/Middleware/QueueMiddlewareInterface.php
+++ b/src/Infrastructure/Queue/Middleware/QueueMiddlewareInterface.php
@@ -18,7 +18,7 @@ use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
 interface QueueMiddlewareInterface
 {
     /**
-     * Handle the command being queued.
+     * Handle the command message or queue job being queued.
      *
      * @param CommandInterface|QueueJobInterface $queueable
      * @param Closure(CommandInterface|QueueJobInterface): void $next

--- a/src/Infrastructure/Queue/Middleware/SetupBeforeDispatch.php
+++ b/src/Infrastructure/Queue/Middleware/SetupBeforeDispatch.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Infrastructure\Queue\Middleware;
+
+use Closure;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
+use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
+
+final class SetupBeforeDispatch implements JobMiddlewareInterface
+{
+    /**
+     * SetupBeforeDispatch constructor.
+     *
+     * @param Closure(): ?Closure(): void $callback
+     */
+    public function __construct(private readonly Closure $callback)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(QueueJobInterface $job, Closure $next): ResultInterface
+    {
+        $tearDown = ($this->callback)();
+
+        assert(
+            $tearDown === null || $tearDown instanceof Closure,
+            'Expecting setup function to return null or a teardown closure.',
+        );
+
+        try {
+            return $next($job);
+        } finally {
+            if ($tearDown) {
+                $tearDown();
+            }
+        }
+    }
+}

--- a/src/Infrastructure/Queue/Middleware/TearDownAfterDispatch.php
+++ b/src/Infrastructure/Queue/Middleware/TearDownAfterDispatch.php
@@ -15,14 +15,26 @@ use Closure;
 use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
 use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
 
-interface JobMiddlewareInterface
+final class TearDownAfterDispatch implements JobMiddlewareInterface
 {
     /**
-     * Handle the queue job.
+     * TearDownAfterDispatch constructor.
      *
-     * @param QueueJobInterface $job
-     * @param Closure(QueueJobInterface): ResultInterface<mixed> $next
-     * @return ResultInterface<mixed>
+     * @param Closure(): void $callback
      */
-    public function __invoke(QueueJobInterface $job, Closure $next): ResultInterface;
+    public function __construct(private readonly Closure $callback)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(QueueJobInterface $job, Closure $next): ResultInterface
+    {
+        try {
+            return $next($job);
+        } finally {
+            ($this->callback)();
+        }
+    }
 }

--- a/src/Infrastructure/Queue/QueueDispatcherInterface.php
+++ b/src/Infrastructure/Queue/QueueDispatcherInterface.php
@@ -11,15 +11,15 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Infrastructure\Queue;
 
-use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
+use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
 
-interface EnqueuerContainerInterface
+interface QueueDispatcherInterface
 {
     /**
-     * Get an enqueuer for the provided command.
+     * Dispatch the given queue job.
      *
-     * @param class-string<CommandInterface> $command
-     * @return EnqueuerInterface
+     * @param QueueJobInterface $queueable
+     * @return ResultInterface<mixed>
      */
-    public function get(string $command): EnqueuerInterface;
+    public function dispatch(QueueJobInterface $queueable): ResultInterface;
 }

--- a/src/Infrastructure/Queue/QueueInterface.php
+++ b/src/Infrastructure/Queue/QueueInterface.php
@@ -16,10 +16,10 @@ use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
 interface QueueInterface
 {
     /**
-     * Push a command or commands onto the queue.
+     * Push a command or queue job onto thw queue.
      *
-     * @param CommandInterface|iterable<CommandInterface> $command
+     * @param CommandInterface|QueueJobInterface $queueable
      * @return void
      */
-    public function push(CommandInterface|iterable $command): void;
+    public function push(CommandInterface|QueueJobInterface $queueable): void;
 }

--- a/src/Infrastructure/Queue/QueueJobDispatcherInterface.php
+++ b/src/Infrastructure/Queue/QueueJobDispatcherInterface.php
@@ -13,13 +13,13 @@ namespace CloudCreativity\Modules\Infrastructure\Queue;
 
 use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
 
-interface QueueDispatcherInterface
+interface QueueJobDispatcherInterface
 {
     /**
      * Dispatch the given queue job.
      *
-     * @param QueueJobInterface $queueable
+     * @param QueueJobInterface $job
      * @return ResultInterface<mixed>
      */
-    public function dispatch(QueueJobInterface $queueable): ResultInterface;
+    public function dispatch(QueueJobInterface $job): ResultInterface;
 }

--- a/src/Infrastructure/Queue/QueueJobHandler.php
+++ b/src/Infrastructure/Queue/QueueJobHandler.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Infrastructure\Queue;
+
+use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
+
+final class QueueJobHandler implements QueueJobHandlerInterface
+{
+    /**
+     * QueueJobHandler constructor.
+     *
+     * @param object $handler
+     */
+    public function __construct(private readonly object $handler)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(QueueJobInterface $job): ResultInterface
+    {
+        assert(method_exists($this->handler, 'execute'), sprintf(
+            'Cannot dispatch "%s" - handler "%s" does not have an execute method.',
+            $job::class,
+            $this->handler::class,
+        ));
+
+        return $this->handler->execute($job);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function middleware(): array
+    {
+        if ($this->handler instanceof DispatchThroughMiddleware) {
+            return $this->handler->middleware();
+        }
+
+        return [];
+    }
+}

--- a/src/Infrastructure/Queue/QueueJobHandlerContainer.php
+++ b/src/Infrastructure/Queue/QueueJobHandlerContainer.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Infrastructure\Queue;
+
+use Closure;
+use RuntimeException;
+
+final class QueueJobHandlerContainer implements QueueJobHandlerContainerInterface
+{
+    /**
+     * @var array<string, Closure>
+     */
+    private array $bindings = [];
+
+    /**
+     * Bind a queue job handler into the container.
+     *
+     * @param string $jobClass
+     * @param Closure $binding
+     * @return void
+     */
+    public function bind(string $jobClass, Closure $binding): void
+    {
+        $this->bindings[$jobClass] = $binding;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get(string $jobClass): QueueJobHandlerInterface
+    {
+        $factory = $this->bindings[$jobClass] ?? null;
+
+        if ($factory) {
+            $innerHandler = $factory();
+            assert(is_object($innerHandler), "Queue job handler binding for {$jobClass} must return an object.");
+            return new QueueJobHandler($innerHandler);
+        }
+
+        throw new RuntimeException('No queue job handler bound for job class: ' . $jobClass);
+    }
+}

--- a/src/Infrastructure/Queue/QueueJobHandlerContainerInterface.php
+++ b/src/Infrastructure/Queue/QueueJobHandlerContainerInterface.php
@@ -11,15 +11,13 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Infrastructure\Queue;
 
-use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
-
-interface QueueInterface
+interface QueueJobHandlerContainerInterface
 {
     /**
-     * Push a command or queue job onto the queue.
+     * Get a queue job handler for the provided queue job.
      *
-     * @param CommandInterface|QueueJobInterface $queueable
-     * @return void
+     * @param string $jobClass
+     * @return QueueJobHandlerInterface
      */
-    public function push(CommandInterface|QueueJobInterface $queueable): void;
+    public function get(string $jobClass): QueueJobHandlerInterface;
 }

--- a/src/Infrastructure/Queue/QueueJobHandlerInterface.php
+++ b/src/Infrastructure/Queue/QueueJobHandlerInterface.php
@@ -11,15 +11,15 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Infrastructure\Queue;
 
-use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
+use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
 
-interface QueueInterface
+interface QueueJobHandlerInterface extends DispatchThroughMiddleware
 {
     /**
-     * Push a command or queue job onto the queue.
+     * Execute the queue job.
      *
-     * @param CommandInterface|QueueJobInterface $queueable
-     * @return void
+     * @param QueueJobInterface $job
+     * @return ResultInterface<mixed>
      */
-    public function push(CommandInterface|QueueJobInterface $queueable): void;
+    public function __invoke(QueueJobInterface $job): ResultInterface;
 }

--- a/src/Infrastructure/Queue/QueueJobInterface.php
+++ b/src/Infrastructure/Queue/QueueJobInterface.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Infrastructure\Queue;
+
+interface QueueJobInterface
+{
+}

--- a/tests/Unit/Bus/CommandDispatcherTest.php
+++ b/tests/Unit/Bus/CommandDispatcherTest.php
@@ -175,25 +175,6 @@ class CommandDispatcherTest extends TestCase
     /**
      * @return void
      */
-    public function testItQueuesManyCommands(): void
-    {
-        $commands = [
-            new TestCommand(),
-            new TestCommand(),
-            new TestCommand(),
-        ];
-
-        $this->queue
-            ->expects($this->once())
-            ->method('push')
-            ->with($this->identicalTo($commands));
-
-        $this->dispatcher->queue($commands);
-    }
-
-    /**
-     * @return void
-     */
     private function willNotQueue(): void
     {
         $this->queue

--- a/tests/Unit/Infrastructure/Queue/ClosureQueueTest.php
+++ b/tests/Unit/Infrastructure/Queue/ClosureQueueTest.php
@@ -54,6 +54,15 @@ class ClosureQueueTest extends TestCase
     /**
      * @return void
      */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->queue, $this->middleware, $this->actual);
+    }
+
+    /**
+     * @return void
+     */
     public function testItQueuesCommand(): void
     {
         $command = $this->createMock(CommandInterface::class);

--- a/tests/Unit/Infrastructure/Queue/ComponentQueueTest.php
+++ b/tests/Unit/Infrastructure/Queue/ComponentQueueTest.php
@@ -53,6 +53,15 @@ class ComponentQueueTest extends TestCase
     /**
      * @return void
      */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->queue, $this->enqueuers, $this->middleware);
+    }
+
+    /**
+     * @return void
+     */
     public function testItQueuesCommand(): void
     {
         $command = $this->createMock(CommandInterface::class);

--- a/tests/Unit/Infrastructure/Queue/Enqueuers/EnqueuerContainerTest.php
+++ b/tests/Unit/Infrastructure/Queue/Enqueuers/EnqueuerContainerTest.php
@@ -9,11 +9,12 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue;
+namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue\Enqueuers;
 
-use CloudCreativity\Modules\Infrastructure\Queue\Enqueuer;
-use CloudCreativity\Modules\Infrastructure\Queue\EnqueuerContainer;
+use CloudCreativity\Modules\Infrastructure\Queue\Enqueuers\Enqueuer;
+use CloudCreativity\Modules\Infrastructure\Queue\Enqueuers\EnqueuerContainer;
 use CloudCreativity\Modules\Tests\Unit\Bus\TestCommand;
+use CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue\TestEnqueuer;
 use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Infrastructure/Queue/Enqueuers/EnqueuerContainerTest.php
+++ b/tests/Unit/Infrastructure/Queue/Enqueuers/EnqueuerContainerTest.php
@@ -14,7 +14,6 @@ namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue\Enqueuers;
 use CloudCreativity\Modules\Infrastructure\Queue\Enqueuers\Enqueuer;
 use CloudCreativity\Modules\Infrastructure\Queue\Enqueuers\EnqueuerContainer;
 use CloudCreativity\Modules\Tests\Unit\Bus\TestCommand;
-use CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue\TestEnqueuer;
 use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Infrastructure/Queue/Enqueuers/EnqueuerTest.php
+++ b/tests/Unit/Infrastructure/Queue/Enqueuers/EnqueuerTest.php
@@ -9,9 +9,11 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue;
+namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue\Enqueuers;
 
-use CloudCreativity\Modules\Infrastructure\Queue\Enqueuer;
+use CloudCreativity\Modules\Infrastructure\Queue\Enqueuers\Enqueuer;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
+use CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue\TestEnqueuer;
 use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -20,7 +22,7 @@ class EnqueuerTest extends TestCase
     /**
      * @return void
      */
-    public function test(): void
+    public function testItPushesCommand(): void
     {
         $command = $this->createMock(CommandInterface::class);
         $innerEnqueuer = $this->createMock(TestEnqueuer::class);
@@ -32,5 +34,22 @@ class EnqueuerTest extends TestCase
 
         $enqueuer = new Enqueuer($innerEnqueuer);
         $enqueuer($command);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItPushesJob(): void
+    {
+        $job = $this->createMock(QueueJobInterface::class);
+        $innerEnqueuer = $this->createMock(TestEnqueuer::class);
+
+        $innerEnqueuer
+            ->expects($this->once())
+            ->method('push')
+            ->with($this->identicalTo($job));
+
+        $enqueuer = new Enqueuer($innerEnqueuer);
+        $enqueuer($job);
     }
 }

--- a/tests/Unit/Infrastructure/Queue/Enqueuers/EnqueuerTest.php
+++ b/tests/Unit/Infrastructure/Queue/Enqueuers/EnqueuerTest.php
@@ -13,7 +13,6 @@ namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue\Enqueuers;
 
 use CloudCreativity\Modules\Infrastructure\Queue\Enqueuers\Enqueuer;
 use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
-use CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue\TestEnqueuer;
 use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Infrastructure/Queue/Enqueuers/TestEnqueuer.php
+++ b/tests/Unit/Infrastructure/Queue/Enqueuers/TestEnqueuer.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue;
+namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue\Enqueuers;
 
 use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
 use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;

--- a/tests/Unit/Infrastructure/Queue/Middleware/ExecuteInUnitOfWorkTest.php
+++ b/tests/Unit/Infrastructure/Queue/Middleware/ExecuteInUnitOfWorkTest.php
@@ -1,0 +1,135 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue\Middleware;
+
+use CloudCreativity\Modules\Infrastructure\Persistence\UnitOfWorkManagerInterface;
+use CloudCreativity\Modules\Infrastructure\Queue\Middleware\ExecuteInUnitOfWork;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
+use CloudCreativity\Modules\Toolkit\Result\Result;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+class ExecuteInUnitOfWorkTest extends TestCase
+{
+    /**
+     * @var array<string>
+     */
+    private array $sequence = [];
+
+    /**
+     * @return void
+     */
+    public function testItCommitsUnitOfWorkOnSuccess(): void
+    {
+        $job = $this->createMock(QueueJobInterface::class);
+        $expected = Result::ok();
+
+        $middleware = new ExecuteInUnitOfWork(
+            $transactions = $this->createMock(UnitOfWorkManagerInterface::class),
+            2,
+        );
+
+        $transactions
+            ->expects($this->once())
+            ->method('execute')
+            ->willReturnCallback(function (\Closure $callback, int $attempts) {
+                $this->assertSame(2, $attempts);
+                $this->sequence[] = 'begin';
+                $result = $callback();
+                $this->sequence[] = 'commit';
+                return $result;
+            });
+
+        $actual = $middleware($job, function ($cmd) use ($job, $expected) {
+            $this->assertSame($job, $cmd);
+            $this->sequence[] = 'handler';
+            return $expected;
+        });
+
+        $this->assertSame(['begin', 'handler', 'commit'], $this->sequence);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItDoesNotCommitUnitOfWorkOnFailure(): void
+    {
+        $job = $this->createMock(QueueJobInterface::class);
+        $expected = Result::failed('Something went wrong.');
+
+        $middleware = new ExecuteInUnitOfWork(
+            $transactions = $this->createMock(UnitOfWorkManagerInterface::class),
+            2,
+        );
+
+        $transactions
+            ->expects($this->once())
+            ->method('execute')
+            ->willReturnCallback(function (\Closure $callback, int $attempts) {
+                $this->assertSame(2, $attempts);
+                $this->sequence[] = 'begin';
+                $result = $callback();
+                $this->sequence[] = 'commit';
+                return $result;
+            });
+
+        $actual = $middleware($job, function ($cmd) use ($job, $expected) {
+            $this->assertSame($job, $cmd);
+            $this->sequence[] = 'handler';
+            return $expected;
+        });
+
+        $this->assertSame(['begin', 'handler'], $this->sequence);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItDoesNotCatchExceptions(): void
+    {
+        $job = $this->createMock(QueueJobInterface::class);
+        $expected = new \RuntimeException('Boom! Something went wrong.');
+
+        $middleware = new ExecuteInUnitOfWork(
+            $transactions = $this->createMock(UnitOfWorkManagerInterface::class),
+            2,
+        );
+
+        $transactions
+            ->expects($this->once())
+            ->method('execute')
+            ->willReturnCallback(function (\Closure $callback, int $attempts) {
+                $this->assertSame(2, $attempts);
+                $this->sequence[] = 'begin';
+                $result = $callback();
+                $this->sequence[] = 'commit';
+                return $result;
+            });
+
+        $actual = null;
+
+        try {
+            $middleware($job, function ($cmd) use ($job, $expected): never {
+                $this->assertSame($job, $cmd);
+                $this->sequence[] = 'handler';
+                throw $expected;
+            });
+        } catch (Throwable $ex) {
+            $actual = $ex;
+        }
+
+        $this->assertSame(['begin', 'handler'], $this->sequence);
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/Unit/Infrastructure/Queue/Middleware/FlushDeferredEventsTest.php
+++ b/tests/Unit/Infrastructure/Queue/Middleware/FlushDeferredEventsTest.php
@@ -1,0 +1,149 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue\Middleware;
+
+use CloudCreativity\Modules\Infrastructure\DomainEventDispatching\DeferredDispatcherInterface;
+use CloudCreativity\Modules\Infrastructure\Queue\Middleware\FlushDeferredEvents;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
+use CloudCreativity\Modules\Toolkit\Result\Result;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class FlushDeferredEventsTest extends TestCase
+{
+    /**
+     * @var MockObject&DeferredDispatcherInterface
+     */
+    private DeferredDispatcherInterface&MockObject $dispatcher;
+
+    /**
+     * @var FlushDeferredEvents
+     */
+    private FlushDeferredEvents $middleware;
+
+    /**
+     * @var array<string>
+     */
+    private array $sequence = [];
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->middleware = new FlushDeferredEvents(
+            $this->dispatcher = $this->createMock(DeferredDispatcherInterface::class),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->dispatcher, $this->middleware);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItFlushesDeferredEvents(): void
+    {
+        $job = $this->createMock(QueueJobInterface::class);
+        $expected = Result::ok();
+
+        $this->dispatcher
+            ->expects($this->once())
+            ->method('flush')
+            ->willReturnCallback(function () {
+                $this->sequence[] = 'flush';
+            });
+
+        $this->dispatcher
+            ->expects($this->never())
+            ->method('forget');
+
+        $actual = ($this->middleware)($job, function ($in) use ($job, $expected) {
+            $this->assertSame($job, $in);
+            $this->sequence[] = 'next';
+            return $expected;
+        });
+
+        $this->assertSame(['next', 'flush'], $this->sequence);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItForgetsDeferredEventsOnFailedResult(): void
+    {
+        $job = $this->createMock(QueueJobInterface::class);
+        $expected = Result::failed('Something went wrong.');
+
+        $this->dispatcher
+            ->expects($this->once())
+            ->method('forget')
+            ->willReturnCallback(function () {
+                $this->sequence[] = 'forget';
+            });
+
+        $this->dispatcher
+            ->expects($this->never())
+            ->method('flush');
+
+        $actual = ($this->middleware)($job, function ($in) use ($job, $expected) {
+            $this->assertSame($job, $in);
+            $this->sequence[] = 'next';
+            return $expected;
+        });
+
+        $this->assertSame(['next', 'forget'], $this->sequence);
+    }
+
+
+    /**
+     * @return void
+     */
+    public function testItForgetsDeferredEventsOnException(): void
+    {
+        $job = $this->createMock(QueueJobInterface::class);
+        $expected = new \LogicException('Boom!');
+
+        $this->dispatcher
+            ->expects($this->once())
+            ->method('forget')
+            ->willReturnCallback(function () {
+                $this->sequence[] = 'forget';
+            });
+
+        $this->dispatcher
+            ->expects($this->never())
+            ->method('flush');
+
+        try {
+            ($this->middleware)($job, function ($in) use ($job, $expected) {
+                $this->assertSame($job, $in);
+                $this->sequence[] = 'next';
+                throw $expected;
+            });
+            $this->fail('No exception thrown.');
+        } catch (\LogicException $ex) {
+            $this->assertSame($expected, $ex);
+        }
+
+        $this->assertSame(['next', 'forget'], $this->sequence);
+    }
+}

--- a/tests/Unit/Infrastructure/Queue/Middleware/SetupBeforeDispatchTest.php
+++ b/tests/Unit/Infrastructure/Queue/Middleware/SetupBeforeDispatchTest.php
@@ -1,0 +1,183 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue\Middleware;
+
+use Closure;
+use CloudCreativity\Modules\Infrastructure\Queue\Middleware\SetupBeforeDispatch;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
+use CloudCreativity\Modules\Toolkit\Result\Result;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class SetupBeforeDispatchTest extends TestCase
+{
+    /**
+     * @var array<string>
+     */
+    private array $sequence = [];
+
+    /**
+     * @return void
+     */
+    public function testItSetsUpAndSucceedsWithoutTeardown(): void
+    {
+        $job = $this->createMock(QueueJobInterface::class);
+        $result = Result::ok();
+
+        $middleware = new SetupBeforeDispatch(function () {
+            $this->sequence[] = 'setup';
+            return null;
+        });
+
+        $actual = $middleware($job, function ($in) use ($job, $result): Result {
+            $this->sequence[] = 'next';
+            $this->assertSame($job, $in);
+            return $result;
+        });
+
+        $this->assertSame($result, $actual);
+        $this->assertSame(['setup', 'next'], $this->sequence);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItSetsUpAndSucceedsWithTeardown(): void
+    {
+        $job = $this->createMock(QueueJobInterface::class);
+        $result = Result::ok();
+
+        $middleware = new SetupBeforeDispatch(function (): Closure {
+            $this->sequence[] = 'setup';
+            return function (): void {
+                $this->sequence[] = 'teardown';
+            };
+        });
+
+        $actual = $middleware($job, function ($in) use ($job, $result): Result {
+            $this->sequence[] = 'next';
+            $this->assertSame($job, $in);
+            return $result;
+        });
+
+        $this->assertSame($result, $actual);
+        $this->assertSame(['setup', 'next', 'teardown'], $this->sequence);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItSetsUpAndFailsWithoutTeardown(): void
+    {
+        $job = $this->createMock(QueueJobInterface::class);
+        $result = Result::failed('Something went wrong.');
+
+        $middleware = new SetupBeforeDispatch(function () {
+            $this->sequence[] = 'setup';
+            return null;
+        });
+
+        $actual = $middleware($job, function ($in) use ($job, $result): Result {
+            $this->sequence[] = 'next';
+            $this->assertSame($job, $in);
+            return $result;
+        });
+
+        $this->assertSame($result, $actual);
+        $this->assertSame(['setup', 'next'], $this->sequence);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItSetsUpAndFailsWithTeardown(): void
+    {
+        $job = $this->createMock(QueueJobInterface::class);
+        $result = Result::failed('Something went wrong.');
+
+        $middleware = new SetupBeforeDispatch(function (): Closure {
+            $this->sequence[] = 'setup';
+            return function (): void {
+                $this->sequence[] = 'teardown';
+            };
+        });
+
+        $actual = $middleware($job, function ($in) use ($job, $result): Result {
+            $this->sequence[] = 'next';
+            $this->assertSame($job, $in);
+            return $result;
+        });
+
+        $this->assertSame($result, $actual);
+        $this->assertSame(['setup', 'next', 'teardown'], $this->sequence);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItSetsUpAndThrowsExceptionWithoutTeardown(): void
+    {
+        $job = $this->createMock(QueueJobInterface::class);
+        $exception = new RuntimeException('Something went wrong.');
+        $actual = null;
+
+        $middleware = new SetupBeforeDispatch(function () {
+            $this->sequence[] = 'setup';
+            return null;
+        });
+
+        try {
+            $middleware($job, function ($in) use ($job, $exception): Result {
+                $this->sequence[] = 'next';
+                $this->assertSame($job, $in);
+                throw $exception;
+            });
+            $this->fail('No exception thrown.');
+        } catch (RuntimeException $ex) {
+            $actual = $ex;
+        }
+
+        $this->assertSame($exception, $actual);
+        $this->assertSame(['setup', 'next'], $this->sequence);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItSetsUpAndThrowsExceptionWithTeardown(): void
+    {
+        $job = $this->createMock(QueueJobInterface::class);
+        $exception = new RuntimeException('Something went wrong.');
+        $actual = null;
+
+        $middleware = new SetupBeforeDispatch(function (): Closure {
+            $this->sequence[] = 'setup';
+            return function (): void {
+                $this->sequence[] = 'teardown';
+            };
+        });
+
+        try {
+            $middleware($job, function ($in) use ($job, $exception): Result {
+                $this->sequence[] = 'next';
+                $this->assertSame($job, $in);
+                throw $exception;
+            });
+            $this->fail('No exception thrown.');
+        } catch (RuntimeException $ex) {
+            $actual = $ex;
+        }
+
+        $this->assertSame($exception, $actual);
+        $this->assertSame(['setup', 'next', 'teardown'], $this->sequence);
+    }
+}

--- a/tests/Unit/Infrastructure/Queue/Middleware/TearDownAfterDispatchTest.php
+++ b/tests/Unit/Infrastructure/Queue/Middleware/TearDownAfterDispatchTest.php
@@ -1,0 +1,96 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue\Middleware;
+
+use CloudCreativity\Modules\Infrastructure\Queue\Middleware\TearDownAfterDispatch;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
+use CloudCreativity\Modules\Toolkit\Result\Result;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class TearDownAfterDispatchTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testItInvokesCallbackAfterSuccess(): void
+    {
+        $job = $this->createMock(QueueJobInterface::class);
+        $result = Result::ok();
+        $sequence = [];
+
+        $middleware = new TearDownAfterDispatch(function () use (&$sequence): void {
+            $sequence[] = 'teardown';
+        });
+
+        $actual = $middleware($job, function ($in) use ($job, $result, &$sequence): Result {
+            $sequence[] = 'next';
+            $this->assertSame($job, $in);
+            return $result;
+        });
+
+        $this->assertSame($result, $actual);
+        $this->assertSame(['next', 'teardown'], $sequence);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItInvokesCallbackAfterFailure(): void
+    {
+        $job = $this->createMock(QueueJobInterface::class);
+        $result = Result::failed('Something went wrong.');
+        $sequence = [];
+
+        $middleware = new TearDownAfterDispatch(function () use (&$sequence): void {
+            $sequence[] = 'teardown';
+        });
+
+        $actual = $middleware($job, function ($in) use ($job, $result, &$sequence): Result {
+            $sequence[] = 'next';
+            $this->assertSame($job, $in);
+            return $result;
+        });
+
+        $this->assertSame($result, $actual);
+        $this->assertSame(['next', 'teardown'], $sequence);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItInvokesCallbackAfterException(): void
+    {
+        $job = $this->createMock(QueueJobInterface::class);
+        $exception = new RuntimeException('Something went wrong.');
+        $actual = null;
+        $sequence = [];
+
+        $middleware = new TearDownAfterDispatch(function () use (&$sequence): void {
+            $sequence[] = 'teardown';
+        });
+
+        try {
+            $middleware($job, function ($in) use ($job, $exception, &$sequence): Result {
+                $sequence[] = 'next';
+                $this->assertSame($job, $in);
+                throw $exception;
+            });
+            $this->fail('No exception thrown.');
+        } catch (RuntimeException $ex) {
+            $actual = $ex;
+        }
+
+        $this->assertSame($exception, $actual);
+        $this->assertSame(['next', 'teardown'], $sequence);
+    }
+}

--- a/tests/Unit/Infrastructure/Queue/QueueJobDispatcherTest.php
+++ b/tests/Unit/Infrastructure/Queue/QueueJobDispatcherTest.php
@@ -1,0 +1,138 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue;
+
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobDispatcher;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobHandlerContainerInterface;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobHandlerInterface;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
+use CloudCreativity\Modules\Toolkit\Pipeline\PipeContainerInterface;
+use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class QueueJobDispatcherTest extends TestCase
+{
+    /**
+     * @var QueueJobHandlerContainerInterface&MockObject
+     */
+    private QueueJobHandlerContainerInterface&MockObject $handlers;
+
+    /**
+     * @var PipeContainerInterface&MockObject
+     */
+    private PipeContainerInterface&MockObject $middleware;
+
+    /**
+     * @var QueueJobDispatcher
+     */
+    private QueueJobDispatcher $dispatcher;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dispatcher = new QueueJobDispatcher(
+            handlers: $this->handlers = $this->createMock(QueueJobHandlerContainerInterface::class),
+            middleware: $this->middleware = $this->createMock(PipeContainerInterface::class),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->dispatcher, $this->handlers, $this->middleware);
+    }
+
+    /**
+     * @return void
+     */
+    public function test(): void
+    {
+        $job = $this->createMock(QueueJobInterface::class);
+
+        $this->handlers
+            ->expects($this->once())
+            ->method('get')
+            ->with($job::class)
+            ->willReturn($handler = $this->createMock(QueueJobHandlerInterface::class));
+
+        $handler
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($job))
+            ->willReturn($expected = $this->createMock(ResultInterface::class));
+
+        $actual = $this->dispatcher->dispatch($job);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @return void
+     */
+    public function testWithMiddleware(): void
+    {
+        $command1 = new TestQueueJob();
+        $command2 = new TestQueueJob();
+        $command3 = new TestQueueJob();
+        $command4 = new TestQueueJob();
+
+        $middleware1 = function (TestQueueJob $job, \Closure $next) use ($command1, $command2) {
+            $this->assertSame($command1, $job);
+            return $next($command2);
+        };
+
+        $middleware2 = function (TestQueueJob $job, \Closure $next) use ($command2, $command3) {
+            $this->assertSame($command2, $job);
+            return $next($command3);
+        };
+
+        $middleware3 = function (TestQueueJob $job, \Closure $next) use ($command3, $command4) {
+            $this->assertSame($command3, $job);
+            return $next($command4);
+        };
+
+        $this->handlers
+            ->method('get')
+            ->with($command1::class)
+            ->willReturn($handler = $this->createMock(QueueJobHandlerInterface::class));
+
+        $this->middleware
+            ->expects($this->once())
+            ->method('get')
+            ->with('MySecondMiddleware')
+            ->willReturn($middleware2);
+
+        $handler
+            ->expects($this->once())
+            ->method('middleware')
+            ->willReturn(['MySecondMiddleware', $middleware3]);
+
+        $handler
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->identicalTo($command4))
+            ->willReturn($expected = $this->createMock(ResultInterface::class));
+
+        $this->dispatcher->through([$middleware1]);
+        $actual = $this->dispatcher->dispatch($command1);
+
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/Unit/Infrastructure/Queue/QueueJobHandlerContainerTest.php
+++ b/tests/Unit/Infrastructure/Queue/QueueJobHandlerContainerTest.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue;
+
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobHandler;
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobHandlerContainer;
+use PHPUnit\Framework\TestCase;
+
+class QueueJobHandlerContainerTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function test(): void
+    {
+        $a = new TestQueueJobHandler();
+        $b = $this->createMock(TestQueueJobHandlerInterface::class);
+
+        $container = new QueueJobHandlerContainer();
+        $container->bind('JobClassA', fn () => $a);
+        $container->bind('JobClassB', fn () => $b);
+
+        $this->assertEquals(new QueueJobHandler($a), $container->get('JobClassA'));
+        $this->assertEquals(new QueueJobHandler($b), $container->get('JobClassB'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('No queue job handler bound for job class: JobClassC');
+
+        $container->get('JobClassC');
+    }
+}

--- a/tests/Unit/Infrastructure/Queue/QueueJobHandlerTest.php
+++ b/tests/Unit/Infrastructure/Queue/QueueJobHandlerTest.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue;
+
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobHandler;
+use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
+use PHPUnit\Framework\TestCase;
+
+class QueueJobHandlerTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function test(): void
+    {
+        $command = new TestQueueJob();
+
+        $innerHandler = $this->createMock(TestQueueJobHandler::class);
+        $innerHandler
+            ->expects($this->once())
+            ->method('execute')
+            ->with($this->identicalTo($command))
+            ->willReturn($expected = $this->createMock(ResultInterface::class));
+
+        $innerHandler
+            ->expects($this->once())
+            ->method('middleware')
+            ->willReturn($middleware = ['Middleware1', 'Middleware2']);
+
+        $handler = new QueueJobHandler($innerHandler);
+
+        $this->assertSame($expected, $handler($command));
+        $this->assertSame($middleware, $handler->middleware());
+    }
+
+    /**
+     * @return void
+     */
+    public function testItDoesNotHaveExecuteMethod(): void
+    {
+        $handler = new QueueJobHandler(new \DateTime());
+        $command = new TestQueueJob();
+        $commandClass = $command::class;
+
+        $this->expectException(\AssertionError::class);
+        $this->expectExceptionMessage(
+            "Cannot dispatch \"{$commandClass}\" - handler \"DateTime\" does not have an execute method.",
+        );
+
+        $handler($command);
+    }
+}

--- a/tests/Unit/Infrastructure/Queue/TestQueueJob.php
+++ b/tests/Unit/Infrastructure/Queue/TestQueueJob.php
@@ -1,0 +1,18 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue;
+
+use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
+
+class TestQueueJob implements QueueJobInterface
+{
+}

--- a/tests/Unit/Infrastructure/Queue/TestQueueJobHandler.php
+++ b/tests/Unit/Infrastructure/Queue/TestQueueJobHandler.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue;
+
+use CloudCreativity\Modules\Infrastructure\Queue\DispatchThroughMiddleware;
+use CloudCreativity\Modules\Toolkit\Result\Result;
+use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
+
+class TestQueueJobHandler implements TestQueueJobHandlerInterface, DispatchThroughMiddleware
+{
+    /**
+     * @inheritDoc
+     */
+    public function execute(TestQueueJob $job): ResultInterface
+    {
+        return Result::ok();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function middleware(): array
+    {
+        return [];
+    }
+}

--- a/tests/Unit/Infrastructure/Queue/TestQueueJobHandlerInterface.php
+++ b/tests/Unit/Infrastructure/Queue/TestQueueJobHandlerInterface.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue;
+
+use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
+
+interface TestQueueJobHandlerInterface
+{
+    /**
+     * @param TestQueueJob $job
+     * @return ResultInterface<null>
+     */
+    public function execute(TestQueueJob $job): ResultInterface;
+}

--- a/tests/Unit/Toolkit/ModuleBasenameTest.php
+++ b/tests/Unit/Toolkit/ModuleBasenameTest.php
@@ -23,34 +23,49 @@ class ModuleBasenameTest extends TestCase
     {
         return [
             [
-                'CloudCreativity\Application\Modules\WaitList\BoundedContext\Application\Commands\ScheduleDelayedProcess\ScheduleDelayedProcessCommand',
+                'App\Modules\WaitList\BoundedContext\Application\Commands\ScheduleDelayedProcess\ScheduleDelayedProcessCommand',
                 'WaitList',
                 'ScheduleDelayedProcessCommand',
             ],
             [
-                'CloudCreativity\Application\Modules\WaitList\BoundedContext\Application\Queries\GetScheduledProcessList\GetScheduledProcessListQuery',
+                'App\Modules\WaitList\Application\Commands\ScheduleDelayedProcess\ScheduleDelayedProcessCommand',
+                'WaitList',
+                'ScheduleDelayedProcessCommand',
+            ],
+            [
+                'App\Modules\WaitList\BoundedContext\Application\Queries\GetScheduledProcessList\GetScheduledProcessListQuery',
                 'WaitList',
                 'GetScheduledProcessListQuery',
             ],
             [
-                'CloudCreativity\Application\Modules\Podcasts\BoundedContext\Application\IntegrationEvents\Outbound\PodcastPublished',
+                'App\Modules\WaitList\Application\Queries\GetScheduledProcessList\GetScheduledProcessListQuery',
+                'WaitList',
+                'GetScheduledProcessListQuery',
+            ],
+            [
+                'Vendor\Modules\Podcasts\Shared\IntegrationEvents\PodcastPublished',
                 'Podcasts',
                 'PodcastPublished',
             ],
             [
-                'CloudCreativity\Application\Modules\Checkout\Shared\IntegrationEvents\Inbound\OrderCompleted',
-                'Checkout',
-                'OrderCompleted',
+                'Vendor\Modules\Podcasts\Shared\IntegrationEvents\PodcastPublished',
+                'Podcasts',
+                'PodcastPublished',
             ],
             [
-                'CloudCreativity\Application\Modules\WaitList\BoundedContext\Domain\Events\TicketsWereReleased',
+                'App\Modules\WaitList\BoundedContext\Domain\Events\TicketsWereReleased',
                 'WaitList',
                 'TicketsWereReleased',
             ],
             [
-                'CloudCreativity\Application\Modules\WaitList\BoundedContext\Infrastructure\Queue\ProcessWaitListDto',
+                'App\Modules\WaitList\BoundedContext\Infrastructure\Queue\ProcessWaitList\ProcessWaitListJob',
                 'WaitList',
-                'ProcessWaitListDto',
+                'ProcessWaitListJob',
+            ],
+            [
+                'App\Modules\WaitList\Infrastructure\Queue\ProcessWaitList\ProcessWaitListJob',
+                'WaitList',
+                'ProcessWaitListJob',
             ],
             [
                 'Foo\Bar\Modules\Ordering\BoundedContext\Baz\Bat\FooBarCommand',
@@ -58,14 +73,19 @@ class ModuleBasenameTest extends TestCase
                 'FooBarCommand',
             ],
             [
-                'CloudCreativity\Application\Modules\BatchMailer\BoundedContext\Application\Commands\SendEmail\SendEmailCommand',
+                'App\Modules\BatchMailer\BoundedContext\Application\Commands\SendEmail\SendEmailCommand',
                 'BatchMailer',
                 'SendEmailCommand',
             ],
             [
-                'CloudCreativity\Application\Modules\BatchMailer\BoundedContext\Infrastructure\Queue\SendEmailDto',
+                'App\Modules\BatchMailer\Application\Commands\SendEmail\SendEmailCommand',
                 'BatchMailer',
-                'SendEmailDto',
+                'SendEmailCommand',
+            ],
+            [
+                'App\Modules\BatchMailer\Infrastructure\Queue\SendEmail\SendEmailJob',
+                'BatchMailer',
+                'SendEmailJob',
             ],
         ];
     }


### PR DESCRIPTION
Final queue implementation for the next release.

This allows external queueing, by queuing command messages and then dispatching them to the command bus.

But it also allows internal queuing, via queue jobs that are a concern of the infrastructure layer - and therefore an internal implementation detail of the bounded context.