### PR TITLE
Feature: add abort method to result object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file. This projec
   change only breaks your implementation if you have manually implemented the command dispatch interface.
 - The `FailedResultException` now implements the `ContextProviderInterface` to get log context from the exception's
   result object. In Laravel applications, this means the exception context will automatically be logged.
+- The `ResultInterface` has a new `abort()` method. This throws a `FailedResultException` if the result is not
+  successful.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this project will be documented in this file. This projec
 - **BREAKING** the `ResultContext` and `ObjectContext` helper classes have been moved to the `Toolkit\Loggable`
   namespace.
 - **BREAKING** The event bus's `IntegrationEventMiddlewareInterface` has been renamed to `EventBusMiddlewareInterface`.
+- **BREAKING** The `ResultInterface::value()` method now throws a `FailedResultException` if the result is not
+  successful. Previously it threw a `ContractException`.
 
 ### Removed
 

--- a/docs/guide/toolkit/results.md
+++ b/docs/guide/toolkit/results.md
@@ -259,5 +259,5 @@ if ($result->didFail()) {
 The exception message will be set to the first error message in the result, if there is one. Any code that catches
 this exception can access the result object using the `getResult()` method.
 
-When you call the `abort()` method on a result, the result object will throw a `FailedResultException` if it is a
-failure.
+When you call the `abort()` or `value()` methods on a result, the result object will throw a `FailedResultException` if
+it is not a successful result.

--- a/docs/guide/toolkit/results.md
+++ b/docs/guide/toolkit/results.md
@@ -36,6 +36,15 @@ if ($result->didFail()) {
 }
 ```
 
+Alternatively, call the `abort()` method to throw a [failed result exception](#exception) if the result is a failure.
+The previous example can be rewritten as follows:
+
+```php
+$result = $bus->dispatch($command);
+$result->abort();
+// here result is definitely a success.
+```
+
 ### Success Values
 
 To return a successful result with a value, pass the value to the `ok()` method:
@@ -78,7 +87,7 @@ return $result->safe();
 ### Failures
 
 When creating a failed result, you must provide something about the error. This can either be a message, an error code
-(expressed as an enum), or an [error object or list of errors](#errors).
+(expressed as a backed enum), or an [error object or list of errors](#errors).
 
 If you provide a string message, the failed result will be created with a single error object with its message set.
 For example:
@@ -249,3 +258,6 @@ if ($result->didFail()) {
 
 The exception message will be set to the first error message in the result, if there is one. Any code that catches
 this exception can access the result object using the `getResult()` method.
+
+When you call the `abort()` method on a result, the result object will throw a `FailedResultException` if it is a
+failure.

--- a/src/Toolkit/Result/Result.php
+++ b/src/Toolkit/Result/Result.php
@@ -89,6 +89,16 @@ final class Result implements ResultInterface
     /**
      * @inheritDoc
      */
+    public function abort(): void
+    {
+        if ($this->didFail()) {
+            throw new FailedResultException($this);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function value(): mixed
     {
         Contracts::assert($this->success, 'Result did not succeed.');

--- a/src/Toolkit/Result/Result.php
+++ b/src/Toolkit/Result/Result.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\Toolkit\Result;
 
 use BackedEnum;
-use CloudCreativity\Modules\Toolkit\Contracts;
 
 /**
  * @template TValue
@@ -91,7 +90,7 @@ final class Result implements ResultInterface
      */
     public function abort(): void
     {
-        if ($this->didFail()) {
+        if ($this->success === false) {
             throw new FailedResultException($this);
         }
     }
@@ -101,9 +100,11 @@ final class Result implements ResultInterface
      */
     public function value(): mixed
     {
-        Contracts::assert($this->success, 'Result did not succeed.');
+        if ($this->success === true) {
+            return $this->value;
+        }
 
-        return $this->value;
+        throw new FailedResultException($this);
     }
 
     /**

--- a/src/Toolkit/Result/ResultInterface.php
+++ b/src/Toolkit/Result/ResultInterface.php
@@ -11,8 +11,6 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Toolkit\Result;
 
-use CloudCreativity\Modules\Toolkit\ContractException;
-
 /**
  * @template-covariant TValue
  */
@@ -40,7 +38,7 @@ interface ResultInterface
      * Get the result value, if the result was successful.
      *
      * @return TValue
-     * @throws ContractException if the result was not successful.
+     * @throws FailedResultException if the result was not successful.
      */
     public function value(): mixed;
 

--- a/src/Toolkit/Result/ResultInterface.php
+++ b/src/Toolkit/Result/ResultInterface.php
@@ -29,6 +29,14 @@ interface ResultInterface
     public function didFail(): bool;
 
     /**
+     * Abort execution if the result failed.
+     *
+     * @return void
+     * @throws FailedResultException if the result is not a success.
+     */
+    public function abort(): void;
+
+    /**
      * Get the result value, if the result was successful.
      *
      * @return TValue

--- a/tests/Unit/Toolkit/Result/ResultTest.php
+++ b/tests/Unit/Toolkit/Result/ResultTest.php
@@ -14,6 +14,7 @@ namespace CloudCreativity\Modules\Tests\Unit\Toolkit\Result;
 use CloudCreativity\Modules\Tests\Unit\Toolkit\Loggable\TestEnum;
 use CloudCreativity\Modules\Toolkit\ContractException;
 use CloudCreativity\Modules\Toolkit\Result\Error;
+use CloudCreativity\Modules\Toolkit\Result\FailedResultException;
 use CloudCreativity\Modules\Toolkit\Result\ListOfErrors;
 use CloudCreativity\Modules\Toolkit\Result\ListOfErrorsInterface;
 use CloudCreativity\Modules\Toolkit\Result\Meta;
@@ -29,6 +30,7 @@ class ResultTest extends TestCase
     public function testOk(): void
     {
         $result = Result::ok();
+        $result->abort();
 
         $this->assertInstanceOf(ResultInterface::class, $result);
         $this->assertNull($result->value());
@@ -73,6 +75,21 @@ class ResultTest extends TestCase
         $this->assertSame('Something went wrong.', $result->error());
 
         return $result;
+    }
+
+    /**
+     * @param Result<mixed> $result
+     * @return void
+     * @depends testFailed
+     */
+    public function testAbort(Result $result): void
+    {
+        try {
+            $result->abort();
+            $this->fail('No exception thrown.');
+        } catch (FailedResultException $ex) {
+            $this->assertSame($result, $ex->getResult());
+        }
     }
 
     /**

--- a/tests/Unit/Toolkit/Result/ResultTest.php
+++ b/tests/Unit/Toolkit/Result/ResultTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\Tests\Unit\Toolkit\Result;
 
 use CloudCreativity\Modules\Tests\Unit\Toolkit\Loggable\TestEnum;
-use CloudCreativity\Modules\Toolkit\ContractException;
 use CloudCreativity\Modules\Toolkit\Result\Error;
 use CloudCreativity\Modules\Toolkit\Result\FailedResultException;
 use CloudCreativity\Modules\Toolkit\Result\ListOfErrors;
@@ -116,10 +115,12 @@ class ResultTest extends TestCase
      */
     public function testItThrowsWhenGettingValueOnFailedResult(Result $result): void
     {
-        $this->expectException(ContractException::class);
-        $this->expectExceptionMessage('Result did not succeed.');
-
-        $result->value();
+        try {
+            $result->value();
+            $this->fail('No exception thrown.');
+        } catch (FailedResultException $ex) {
+            $this->assertSame($result, $ex->getResult());
+        }
     }
 
     /**


### PR DESCRIPTION
This new method throws a `FailedResultException` if the result is a failure; otherwise it does nothing. This means the following:

```php
$result = $bus->dispatch($command);

if ($result->didFail()) {
    throw new FailedResultException($result);
}
```

can be rewritten as:

```php
$result = $bus->dispatch($command);
$result->abort();
// here result is definitely a success.
```

This PR also changes the `ResultInterface::value()` method to throw `FailedResultException` if attempting to get a value from a failed result. Previously it threw a `ContractException` - but the failed result exception makes more sense as it contains the originating result.