### PR TITLE
Refactor: rename unit of work namespace and add chapter on the unit of work pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file. This projec
 - **BREAKING** The event bus's `IntegrationEventMiddlewareInterface` has been renamed to `EventBusMiddlewareInterface`.
 - **BREAKING** The `ResultInterface::value()` method now throws a `FailedResultException` if the result is not
   successful. Previously it threw a `ContractException`.
+- **BREAKING** The `Infrastructure\Persistence` namespace has been renamed `Infrastructure\UnitOfWork`.
 
 ### Removed
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -50,6 +50,8 @@ export default defineConfig({
                     collapsed: true,
                     items: [
                         {text: 'Asynchronous Processing', link: '/guide/infrastructure/queues'},
+                        {text: 'Domain Event Dispatching', link: '/guide/infrastructure/domain-event-dispatchers'},
+                        {text: 'Exception Reporting', link: '/guide/infrastructure/exception-reporting'},
                         {text: 'Outbox & Inbox', link: '/guide/infrastructure/outbox-inbox'},
                         {text: 'Persistence', link: '/guide/infrastructure/persistence'},
                         {text: 'Units of Work', link: '/guide/infrastructure/units-of-work'},

--- a/docs/guide/infrastructure/domain-event-dispatchers.md
+++ b/docs/guide/infrastructure/domain-event-dispatchers.md
@@ -1,0 +1,3 @@
+# Dispatching Domain Events
+
+TODO

--- a/docs/guide/infrastructure/exception-reporting.md
+++ b/docs/guide/infrastructure/exception-reporting.md
@@ -1,0 +1,3 @@
+# Reporting Exceptions
+
+TODO

--- a/docs/guide/infrastructure/units-of-work.md
+++ b/docs/guide/infrastructure/units-of-work.md
@@ -1,3 +1,538 @@
 # Units of Work
 
-TODO
+Domain driven design emphasises the importance of the domain model and the business logic that is encapsulated within,
+over infrastructure concerns. As your domain model grows in complexity, one of the challenges you will face is ensuring
+that all operations are executed in a consistent and reliable manner.
+
+Commands that mutate the state of your bounded context must be _atomic_ - they must either succeed or fail as a whole.
+This is where the concept of a _unit of work_ comes in.
+
+A unit of work is a design pattern that defines the boundary when a transaction starts and ends. It ensures that
+all operations within that transaction succeed or fail together. This helps achieve data consistency, particularly when
+your domain model has no concept of how it is persisted.
+
+## Scenario
+
+Consider the following scenario. Our domain models the attendees at an in-person event as having one-to-many tickets.
+When we want to cancel a ticket for an attendee, we do this via the attendee aggregate root that contains the ticket
+entities. This is because our domain logic says that state of the attendee may change as a consequence of cancelling
+the ticket.
+
+Our command handler might look like this:
+
+```php
+namespace App\Modules\EventManagement\BoundedContext\Application\Commands\CancelAttendeeTicket;
+
+use App\Modules\EventManagement\BoundedContext\Infrastructure\Persistence\AttendeeRepositoryInterface;
+use CloudCreativity\Modules\Toolkit\Results\Result;
+
+final readonly class CancelAttendeeTicketHandler implements
+    CancelAttendeeTicketHandlerInterface
+{
+    public function __construct(
+        private AttendeeRepositoryInterface $attendees,
+    ) {
+    }
+
+    public function handle(CancelAttendeeTicketCommand $command): Result
+    {
+        $attendee = $this->attendees->findOrFail($command->attendeeId);
+
+        // dispatches an "attendee ticket cancelled" domain event
+        // which may cause other parts of the domain to react
+        $attendee->cancelTicket(
+            $command->ticketId,
+            $command->reason,
+        );
+
+        // must persist the aggregate root and entity changes
+        // but we have no knowledge of how this is done
+        $this->attendees->update($attendee);
+
+        return Result::ok();
+    }
+}
+```
+
+### Problem
+
+This implementation poses a number of issues:
+
+1. When the business action - _cancel ticket_ - is performed, the aggregate root and the relevant ticket entity is
+   updated to the new state (as defined by the business logic).
+2. As its state is settled, the aggregate root emits a domain event so that other parts of the domain can react to
+   the change.
+3. The domain event is correctly dispatched when the aggregate root is in a new consistent state. However, at this point
+   the changes have not been persisted. This means side-effects - including other changes in our infrastructure layer -
+   will occur _before_ the ticket cancellation is actually persisted.
+4. As the persistence layer is correctly abstracted behind a repository interface, the command handler has no knowledge
+   of how the changes are persisted. Will the repository do a single write of the new data, or perform multiple
+   writes to persist the updated state?
+5. If the persistence fails, the side-effects of the domain event will have already occurred. This could lead to
+   inconsistencies in the domain. For example, if we publish an integration event as a side-effect of the domain event,
+   that integration event would be published even though the persistence failed.
+
+So is the handler implemented correctly? Should we move the domain event dispatching out of the aggregate root
+so that we can modify the aggregate root, persist the changes, then dispatch the event?
+
+The answer is that the handler is correctly implemented. As we are modelling the business domain, it is correct that the
+aggregate root handles both the state mutation and emits the domain event. This makes the aggregate root descriptive
+of the business logic and emitting the domain event is part of this logic.
+
+Ultimately the problem we're facing is that the domain is correctly modelled, but the sequencing of operations is
+not correct _from an infrastructure perspective_.
+
+### Solution
+
+As we prioritise the domain model over infrastructure concerns, we will leave the domain model as-is. Instead, we need
+to introduce an infrastructure concern that can orchestrate the sequence of operations in the correct order from its
+perspective.
+
+This is where the unit of work comes in. By declaring a start and end to a transaction, operations can be both sequenced
+in the correct infrastructure order and atomic.
+
+Given the above example, the correct order from the infrastructure perspective is:
+
+1. Unit of work begins by starting a transaction.
+2. The aggregate root state change occurs and the domain event is emitted by the aggregate.
+3. The domain event dispatching is deferred until later in the unit of work. This means side-effects via event listeners
+   will be triggered later.
+4. The aggregate root is persisted via the repository interface. Internally this may result in multiple database writes,
+   that are within the transaction.
+5. With the persistence changes successful made (but not yet committed), the deferred domain event is dispatched.
+6. Side-effects of the domain event are triggered, within the transaction boundary. Any side-effects that affect the
+   persistence layer now occur _after_ the aggregate changes were persisted.
+7. The transaction is committed by closing the unit of work. The state changes to the aggregate root and the
+   side-effects are persisted together. They are atomic.
+
+All this is achieved by this package by combining the following:
+
+- **Unit of work** - begins, commits and rolls back a transaction. This is provided by the `UnitOfWorkInterface`, which
+  allows you to implement a transaction for whatever database solution you are using.
+- **Unit of work manager** - handles the lifecycle of the unit of work, e.g. deferring operations for later execution.
+- **Unit of work aware domain event dispatcher** - coordinates domain event dispatching with the unit of work manager.
+- **Unit of work middleware** - that ensure command handlers, integration event notifiers and queue job handlers are
+  executed in a unit of work.
+
+:::info
+The unit of work and unit of work manager are separate implementations, solely to allow you to integrate with your
+preferred database solution. The  manager is a higher-level abstraction (provided by this package) that manages the
+lifecycle of the unit of work.
+:::
+
+Our previous example can be updated to add a unit of work that wraps the command handler execution via middleware:
+
+```php
+namespace App\Modules\EventManagement\BoundedContext\Application\Commands\CancelAttendeeTicket;
+
+use App\Modules\EventManagement\BoundedContext\Infrastructure\Persistence\AttendeeRepositoryInterface;
+use CloudCreativity\Modules\Bus\Middleware\ExecuteInUnitOfWork;
+use CloudCreativity\Modules\Toolkit\Messages\DispatchThroughMiddleware;
+use CloudCreativity\Modules\Toolkit\Results\Result;
+
+final readonly class CancelAttendeeTicketHandler implements
+    CancelAttendeeTicketHandlerInterface,
+    DispatchThroughMiddleware
+{
+    public function __construct(
+        private AttendeeRepositoryInterface $attendees,
+    ) {
+    }
+
+    public function handle(CancelAttendeeTicketCommand $command): Result
+    {
+        $attendee = $this->attendees->findOrFail($command->attendeeId);
+
+        $attendee->cancelTicket(
+            $command->ticketId,
+            $command->reason,
+        );
+
+        $this->attendees->update($attendee);
+
+        return Result::ok();
+    }
+    
+    public function middleware(): array
+    {
+        return [
+            // the last middleware to be executed before the command handler
+            ExecuteInUnitOfWork::class,
+        ];
+    }
+}
+```
+
+## Unit of Work
+
+To implement a unit of work, you need to implement the `UnitOfWorkInterface`:
+
+```php
+namespace CloudCreativity\Modules\Infrastructure\UnitOfWork;
+
+interface UnitOfWorkInterface
+{
+    /**
+     * Execute the callback in a unit of work.
+     *
+     * @param \Closure $callback
+     * @param int $attempts
+     * @return mixed 
+     */
+    public function execute(Closure $callback, int $attempts = 1): mixed;
+}
+```
+
+This allows you to plug our unit of work manager into any database solution you are using. For example, a concrete
+implementation in Laravel could look like this:
+
+```php
+namespace App\Modules\Shared\Infrastructure;
+
+use Closure;
+use CloudCreativity\Modules\Infrastructure\Persistence\UnitOfWorkInterface;
+use Illuminate\Database\ConnectionInterface;
+use Psr\Log\LoggerInterface;
+
+final readonly class IlluminateUnitOfWork implements UnitOfWorkInterface
+{
+    public function __construct(private ConnectionInterface $db)
+    {
+    }
+
+    public function execute(Closure $callback, int $attempts = 1): mixed
+    {
+        return $this->db->transaction(
+            static fn () => $callback(), 
+            $attempts,
+      );
+    }
+}
+```
+
+## Unit of Work Manager
+
+Our unit of work manager implementation handles the complexities of the unit of work lifecycle. When combined with the
+unit of work aware domain event dispatcher, it ensures domain event dispatching and side effects (via listeners) are
+coordinated within the unit of work.
+
+The implementation just requires your concrete unit of work implementation:
+
+```php
+use App\Modules\Shared\Infrastructure\IlluminateUnitOfWork;
+use CloudCreativity\Modules\Infrastructure\UnitOfWork\UnitOfWorkManager;
+
+$manager = new UnitOfWorkManager(new IlluminateUnitOfWork(
+    $this->dependencies->getDatabaseConnection(),
+));
+```
+
+:::info
+The second optional constructor argument of the unit of work manager is an [exception reporter.](./exception-reporting)
+This is useful if the unit of work manager is handling multiple commit attempts. It allows it to report any exceptions
+that occur prior to a re-attempt.
+:::
+
+### Singleton Instance
+
+One really important point to note is that you **must** use a singleton instance of the unit of work manager for the
+duration of the unit of work.
+
+The same instance must be injected both into the domain dispatcher, plus the middleware that wraps command handlers,
+integration event notifiers and queue job handlers.
+
+You can (and should) dispose of this instance once the unit of work is complete. To do this, we provide middleware that
+allows you to setup and tear down the unit of work manager for each operation.
+
+For example, we can use the setup before dispatch middleware on our command bus:
+
+```php
+use App\Modules\Shared\Infrastructure\IlluminateUnitOfWork;
+use CloudCreativity\Modules\Bus\Middleware\SetupBeforeDispatch;
+use CloudCreativity\Modules\Infrastructure\UnitOfWork\UnitOfWorkManager;
+
+$middleware->bind(
+    SetupBeforeDispatch::class,
+    fn () => new SetupBeforeDispatch(function (): Closure {
+        // setup
+        $this->unitOfWorkManager = new UnitOfWorkManager(
+            new IlluminateUnitOfWork(
+                $this->dependencies->getDatabaseConnection(),
+            ),
+        );
+        // tear down        
+        return function (): void {
+            $this->unitOfWorkManager = null;
+        };
+    }),
+);
+```
+
+:::tip
+Middleware is documented in the relevant chapters for
+the [commands](../application/commands#middleware), [integration events](../application/events#middleware)
+and [queue jobs.](./queues#job-middleware)
+:::
+
+### Deferring Work
+
+Use our unit of work aware domain event dispatcher to defer domain events to before the unit of work is committed.
+Coordination of when domain event listeners are triggered can be controlled via interfaces on the event listeners - as
+described later in this chapter.
+
+If you have other use-cases for deferring work, use the following method on the manager:
+
+```php
+$manager->beforeCommit(function (): void {
+    // some deferred work.
+});
+```
+
+It is also possible to defer work to after the unit of work is committed:
+
+```php
+$manager->afterCommit(function (): void {
+    // some deferred work.
+});
+```
+
+## Deferring Domain Events
+
+When using the unit of work pattern, you **must** use the unit of work aware domain event dispatcher. This coordinates
+the dispatching of domain events with the unit of work manager.
+
+The unit of work manager is injected into the domain event dispatcher via its constructor. This is covered in
+the [domain event dispatching chapter](./domain-event-dispatchers), which also describes how to configure listeners and
+domain event middleware.
+
+For the purposes of this chapter, we'll focus on how the domain event dispatcher works with the unit of work manager.
+
+### Event Dispatch
+
+When the dispatcher is asked to emit a domain event (i.e. from an aggregate root or entity), it will defer the event
+dispatching to before the unit of work commits. This means all listeners to that domain event are also deferred.
+
+For clarity, this means that **by default domain events and listeners occur before the unit of work commits**, i.e. any
+side-effects will occur _within_ the unit of work's transaction.
+
+### Immediate Dispatch
+
+Sometimes you may have side effects for domain events that need to occur immediately rather than being deferred. When
+using a unit of work pattern this should not be your default approach - but we recognise that sometimes it is
+unavoidable.
+
+To trigger those side effects immediately, you need to indicate that the domain event should not be deferred when it is
+emitted. Implement the `OccursImmediately` interface on the domain event:
+
+```php
+namespace App\Modules\EventManagement\BoundedContext\Domain\Events;
+
+use CloudCreativity\Modules\Domain\Events\DomainEventInterface;
+use CloudCreativity\Modules\Domain\Events\OccursImmediately;
+
+final readonly class AttendeeTicketCancelled implements
+    DomainEventInterface,
+    OccursImmediately
+{
+    // ...
+}
+```
+
+:::warning
+If you find yourself reaching for immediate dispatch for most or all of your domain events, you may need to reconsider
+the domain design and/or whether a unit of work pattern can actually be followed.
+:::
+
+This immediate dispatch of the domain events allows listeners to be triggered immediately. However, what happens if some
+listeners can actually deferred? Indicate this by implementing the `DispatchBeforeCommit` interface on the listener:
+
+```php
+namespace App\Modules\EventManagement\BoundedContext\Infrastructure\DomainEventListeners;
+
+use CloudCreativity\Modules\Infrastructure\DomainEventDispatching\DispatchBeforeCommit;
+
+final readonly class QueueAttendeeCancellationEmail implements
+    DispatchBeforeCommit
+{
+    // ...
+}
+```
+
+:::tip
+For scenarios where you have to immediately dispatch events, it is advisable to defer as many listeners as possible.
+This helps you stick closely to the unit of work pattern, with the minimal amount of side effects incurred
+immediately.
+:::
+
+### After Commit Listeners
+
+As explained, the default behaviour is to defer domain events and their listeners to before the unit of work commits.
+However, you may have some listeners that need to run after the unit of work commits.
+
+To indicate that a listener should be deferred to after the unit of work commits, implement the `DispatchAfterCommit`
+interface:
+
+```php
+namespace App\Modules\EventManagement\BoundedContext\Infrastructure\DomainEventListeners;
+
+use CloudCreativity\Modules\Infrastructure\DomainEventDispatching\DispatchAfterCommit;
+
+final readonly class QueueAttendeeCancellationEmail implements
+    DispatchAfterCommit
+{
+    // ...
+}
+```
+
+:::warning
+If any work pushed to after the unit of work has committed fails, it is not possible to rollback the transaction. This
+means that the domain's new state will be committed, but your side effect has not occurred. This could lead to data
+inconsistencies.
+
+Use an [Outbox pattern](./outbox-inbox) to ensure data consistency.
+:::
+
+## Using Unit of Works
+
+The unit of work pattern can be implemented on command handlers, integration event notifiers and queue job handlers.
+There is a consistent approach to all - use a middleware that wraps the execution in a unit of work.
+
+As already noted, ensure this middleware is injected with your singleton unit of work manager instance.
+
+:::tip
+In all three scenarios, ensure the unit of work middleware is the last middleware to be executed before the handler.
+This means you should implement it on the handler itself, rather than adding it as bus middleware.
+:::
+
+### Command Handlers
+
+Use the `Bus\Middleware\ExecuteInUnitOfWork` middleware to wrap command handlers in a unit of work:
+
+```php
+namespace App\Modules\EventManagement\BoundedContext\Application\Commands\CancelAttendeeTicket;
+
+use App\Modules\EventManagement\BoundedContext\Infrastructure\Persistence\AttendeeRepositoryInterface;
+use CloudCreativity\Modules\Bus\Middleware\ExecuteInUnitOfWork;
+use CloudCreativity\Modules\Toolkit\Messages\DispatchThroughMiddleware;
+use CloudCreativity\Modules\Toolkit\Results\Result;
+
+final readonly class CancelAttendeeTicketHandler implements
+    CancelAttendeeTicketHandlerInterface,
+    DispatchThroughMiddleware
+{
+    public function __construct(
+        private AttendeeRepositoryInterface $attendees,
+    ) {
+    }
+
+    public function handle(CancelAttendeeTicketCommand $command): Result
+    {
+        $attendee = $this->attendees->findOrFail($command->attendeeId);
+
+        $attendee->cancelTicket(
+            $command->ticketId,
+            $command->reason,
+        );
+
+        $this->attendees->update($attendee);
+
+        return Result::ok();
+    }
+    
+    public function middleware(): array
+    {
+        return [
+            // the last middleware to be executed before the command handler
+            ExecuteInUnitOfWork::class,
+        ];
+    }
+}
+```
+
+### Queue Job Handlers
+
+Use the `Infrastructure\Queue\Middleware\ExecuteInUnitOfWork` middleware to wrap queue job handlers in a unit of work.
+Note that in this scenario, the `DispatchThroughMiddleware` interface is also in the `Infrastructre\Queue` namespace:
+
+```php
+namespace App\Modules\EventManagement\BoundedContext\Infrastructure\Queue\RecalculateSalesAtEvent;
+
+use App\Modules\EventManagement\BoundedContext\Infrastructure\Persistence\AttendanceReportRepositoryInterface;
+use CloudCreativity\Modules\Infrastructure\Queue\DispatchThroughMiddleware;
+use CloudCreativity\Modules\Infrastructure\Queue\Middleware\ExecuteInUnitOfWork;
+use CloudCreativity\Modules\Toolkit\Result\Result;
+
+final readonly class RecalculateSalesAtEventHandler implements 
+    RecalculateSalesAtEventHandlerInterface,
+    DispatchThroughMiddleware
+{
+    public function __construct(private AttendanceReportRepositoryInterface $repository)
+    {
+    }
+
+    public function execute(RecalculateSalesAtEventJob $job): Result
+    {
+        $report = $this->repository->findOrCreate($job->eventId);
+        
+        $report->recalculate();
+        
+        $this->repository->save($report);
+        
+        return Result::ok();
+    }
+    
+    public function middleware(): array
+    {
+        return [
+            ExecuteInUnitOfWork::class,
+        ];
+    }
+}
+```
+
+### Integration Event Handlers
+
+As explained in the [integration events chapter](../application/events), there are several strategies that can be used
+to handle inbound events.
+
+If you dispatch a command or queue job as a result of the inbound event, you do not need to worry about the unit of work
+on the inbound event handler. Instead, the unit of work should be implemented by the command or queue job handler.
+
+However, an alternative approach is to map the inbound integration event to a domain event. If using this approach, you
+will need to wrap the dispatch of the domain event in a unit of work. This ensures side effects are properly
+orchestrated by the unit of work manager and are atomic.
+
+This can be achieved via the `EventBus\Middleware\NotifyInUnitOfWork` middleware on the inbound event handler:
+
+```php
+namespace App\Modules\EventManagement\BoundedContext\Application\IntegrationEvents\Inbound;
+
+use App\Modules\EventManagement\BoundedContext\Domain\Events\SalesAtEventDidChange;
+use App\Modules\Ordering\Shared\IntegrationEvents\OrderWasFulfilled;
+use CloudCreativity\Modules\Domain\Events\DispatcherInterface;
+use CloudCreativity\Modules\EventBus\Middleware\NotifyInUnitOfWork;
+use CloudCreativity\Modules\Toolkit\Messages\DispatchThroughMiddleware;
+
+final readonly class OrderWasFulfilledHandler implements
+    DispatchThroughMiddleware
+{
+    public function __construct(
+        private DispatcherInterface $domainEvents,
+    ) {
+    }
+
+    public function handle(OrderWasFulfilled $event): void
+    {
+        $this->domainEvents->dispatch(new SalesAtEventDidChange(
+            eventId: $event->eventId,
+        ));
+    }
+
+    public function middleware(): array
+    {
+        return [
+            NotifyInUnitOfWork::class,
+        ];
+    }
+}
+```

--- a/src/Bus/Middleware/ExecuteInUnitOfWork.php
+++ b/src/Bus/Middleware/ExecuteInUnitOfWork.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\Bus\Middleware;
 
 use Closure;
-use CloudCreativity\Modules\Infrastructure\Persistence\AbortOnFailureException;
-use CloudCreativity\Modules\Infrastructure\Persistence\UnitOfWorkManagerInterface;
+use CloudCreativity\Modules\Infrastructure\UnitOfWork\AbortOnFailureException;
+use CloudCreativity\Modules\Infrastructure\UnitOfWork\UnitOfWorkManagerInterface;
 use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
 use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
 

--- a/src/EventBus/Middleware/NotifyInUnitOfWork.php
+++ b/src/EventBus/Middleware/NotifyInUnitOfWork.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\EventBus\Middleware;
 
 use Closure;
-use CloudCreativity\Modules\Infrastructure\Persistence\UnitOfWorkManagerInterface;
+use CloudCreativity\Modules\Infrastructure\UnitOfWork\UnitOfWorkManagerInterface;
 use CloudCreativity\Modules\Toolkit\Messages\IntegrationEventInterface;
 
 final class NotifyInUnitOfWork implements EventBusMiddlewareInterface

--- a/src/Infrastructure/DomainEventDispatching/UnitOfWorkAwareDispatcher.php
+++ b/src/Infrastructure/DomainEventDispatching/UnitOfWorkAwareDispatcher.php
@@ -13,7 +13,7 @@ namespace CloudCreativity\Modules\Infrastructure\DomainEventDispatching;
 
 use CloudCreativity\Modules\Domain\Events\DomainEventInterface;
 use CloudCreativity\Modules\Domain\Events\OccursImmediately;
-use CloudCreativity\Modules\Infrastructure\Persistence\UnitOfWorkManagerInterface;
+use CloudCreativity\Modules\Infrastructure\UnitOfWork\UnitOfWorkManagerInterface;
 use CloudCreativity\Modules\Toolkit\Pipeline\PipeContainerInterface;
 
 class UnitOfWorkAwareDispatcher extends Dispatcher implements DispatcherInterface

--- a/src/Infrastructure/Queue/Middleware/ExecuteInUnitOfWork.php
+++ b/src/Infrastructure/Queue/Middleware/ExecuteInUnitOfWork.php
@@ -12,9 +12,9 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\Infrastructure\Queue\Middleware;
 
 use Closure;
-use CloudCreativity\Modules\Infrastructure\Persistence\AbortOnFailureException;
-use CloudCreativity\Modules\Infrastructure\Persistence\UnitOfWorkManagerInterface;
 use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
+use CloudCreativity\Modules\Infrastructure\UnitOfWork\AbortOnFailureException;
+use CloudCreativity\Modules\Infrastructure\UnitOfWork\UnitOfWorkManagerInterface;
 use CloudCreativity\Modules\Toolkit\Result\ResultInterface;
 
 final class ExecuteInUnitOfWork implements JobMiddlewareInterface

--- a/src/Infrastructure/UnitOfWork/AbortOnFailureException.php
+++ b/src/Infrastructure/UnitOfWork/AbortOnFailureException.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Infrastructure\Persistence;
+namespace CloudCreativity\Modules\Infrastructure\UnitOfWork;
 
 use CloudCreativity\Modules\Toolkit\Result\FailedResultException;
 

--- a/src/Infrastructure/UnitOfWork/UnitOfWorkInterface.php
+++ b/src/Infrastructure/UnitOfWork/UnitOfWorkInterface.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Infrastructure\Persistence;
+namespace CloudCreativity\Modules\Infrastructure\UnitOfWork;
 
 use Closure;
 

--- a/src/Infrastructure/UnitOfWork/UnitOfWorkManager.php
+++ b/src/Infrastructure/UnitOfWork/UnitOfWorkManager.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Infrastructure\Persistence;
+namespace CloudCreativity\Modules\Infrastructure\UnitOfWork;
 
 use Closure;
 use CloudCreativity\Modules\Infrastructure\InfrastructureException;

--- a/src/Infrastructure/UnitOfWork/UnitOfWorkManagerInterface.php
+++ b/src/Infrastructure/UnitOfWork/UnitOfWorkManagerInterface.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Infrastructure\Persistence;
+namespace CloudCreativity\Modules\Infrastructure\UnitOfWork;
 
 use Closure;
 

--- a/tests/Unit/Bus/Middleware/ExecuteInUnitOfWorkTest.php
+++ b/tests/Unit/Bus/Middleware/ExecuteInUnitOfWorkTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\Tests\Unit\Bus\Middleware;
 
 use CloudCreativity\Modules\Bus\Middleware\ExecuteInUnitOfWork;
-use CloudCreativity\Modules\Infrastructure\Persistence\UnitOfWorkManagerInterface;
+use CloudCreativity\Modules\Infrastructure\UnitOfWork\UnitOfWorkManagerInterface;
 use CloudCreativity\Modules\Toolkit\Messages\CommandInterface;
 use CloudCreativity\Modules\Toolkit\Result\Result;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/EventBus/Middleware/NotifyInUnitOfWorkTest.php
+++ b/tests/Unit/EventBus/Middleware/NotifyInUnitOfWorkTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\Tests\Unit\EventBus\Middleware;
 
 use CloudCreativity\Modules\EventBus\Middleware\NotifyInUnitOfWork;
-use CloudCreativity\Modules\Infrastructure\Persistence\UnitOfWorkManagerInterface;
+use CloudCreativity\Modules\Infrastructure\UnitOfWork\UnitOfWorkManagerInterface;
 use CloudCreativity\Modules\Toolkit\Messages\IntegrationEventInterface;
 use PHPUnit\Framework\TestCase;
 use Throwable;

--- a/tests/Unit/Infrastructure/DomainEventDispatching/UnitOfWorkAwareDispatcherTest.php
+++ b/tests/Unit/Infrastructure/DomainEventDispatching/UnitOfWorkAwareDispatcherTest.php
@@ -17,7 +17,7 @@ use CloudCreativity\Modules\Infrastructure\DomainEventDispatching\DispatchAfterC
 use CloudCreativity\Modules\Infrastructure\DomainEventDispatching\DispatchBeforeCommit;
 use CloudCreativity\Modules\Infrastructure\DomainEventDispatching\ListenerContainerInterface;
 use CloudCreativity\Modules\Infrastructure\DomainEventDispatching\UnitOfWorkAwareDispatcher;
-use CloudCreativity\Modules\Infrastructure\Persistence\UnitOfWorkManagerInterface;
+use CloudCreativity\Modules\Infrastructure\UnitOfWork\UnitOfWorkManagerInterface;
 use CloudCreativity\Modules\Toolkit\Pipeline\PipeContainerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Infrastructure/Queue/Middleware/ExecuteInUnitOfWorkTest.php
+++ b/tests/Unit/Infrastructure/Queue/Middleware/ExecuteInUnitOfWorkTest.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue\Middleware;
 
-use CloudCreativity\Modules\Infrastructure\Persistence\UnitOfWorkManagerInterface;
 use CloudCreativity\Modules\Infrastructure\Queue\Middleware\ExecuteInUnitOfWork;
 use CloudCreativity\Modules\Infrastructure\Queue\QueueJobInterface;
+use CloudCreativity\Modules\Infrastructure\UnitOfWork\UnitOfWorkManagerInterface;
 use CloudCreativity\Modules\Toolkit\Result\Result;
 use PHPUnit\Framework\TestCase;
 use Throwable;

--- a/tests/Unit/Infrastructure/UnitOfWork/UnitOfWorkManagerTest.php
+++ b/tests/Unit/Infrastructure/UnitOfWork/UnitOfWorkManagerTest.php
@@ -9,13 +9,13 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Persistence;
+namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\UnitOfWork;
 
 use Closure;
 use CloudCreativity\Modules\Infrastructure\InfrastructureException;
 use CloudCreativity\Modules\Infrastructure\Log\ExceptionReporterInterface;
-use CloudCreativity\Modules\Infrastructure\Persistence\UnitOfWorkInterface;
-use CloudCreativity\Modules\Infrastructure\Persistence\UnitOfWorkManager;
+use CloudCreativity\Modules\Infrastructure\UnitOfWork\UnitOfWorkInterface;
+use CloudCreativity\Modules\Infrastructure\UnitOfWork\UnitOfWorkManager;
 use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
This PR changes the `Infrastructure\Persistence` namespace to `Infrastructure\UnitOfWork`. This is better as the namespace only contains the tools for implementing a unit of work pattern - and there's no generic persistence tools provided by the package.

Also adds the unit of work chapter at the same time.