### PR TITLE
Build: add PHP 8.4 to automated tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.1, 8.2, 8.3 ]
+        php: [ 8.1, 8.2, 8.3, 8.4 ]
 
     steps:
       - name: Checkout Code

--- a/src/Contracts/Toolkit/Pipeline/PipelineBuilder.php
+++ b/src/Contracts/Toolkit/Pipeline/PipelineBuilder.php
@@ -35,5 +35,5 @@ interface PipelineBuilder
      * @param Processor|null $processor
      * @return Pipeline
      */
-    public function build(Processor $processor = null): Pipeline;
+    public function build(?Processor $processor = null): Pipeline;
 }

--- a/src/Toolkit/Identifiers/LazyListOfGuids.php
+++ b/src/Toolkit/Identifiers/LazyListOfGuids.php
@@ -30,7 +30,7 @@ final class LazyListOfGuids implements LazyList
      *
      * @param Closure(): Generator<Guid>|null $source
      */
-    public function __construct(Closure $source = null)
+    public function __construct(?Closure $source = null)
     {
         $this->source = $source;
     }

--- a/src/Toolkit/Identifiers/LazyListOfIdentifiers.php
+++ b/src/Toolkit/Identifiers/LazyListOfIdentifiers.php
@@ -30,7 +30,7 @@ final class LazyListOfIdentifiers implements LazyList
      *
      * @param Closure(): Generator<Identifier>|null $source
      */
-    public function __construct(Closure $source = null)
+    public function __construct(?Closure $source = null)
     {
         $this->source = $source;
     }

--- a/src/Toolkit/Identifiers/LazyListOfIntegerIds.php
+++ b/src/Toolkit/Identifiers/LazyListOfIntegerIds.php
@@ -29,7 +29,7 @@ final class LazyListOfIntegerIds implements LazyList
      *
      * @param Closure(): Generator<IntegerId>|null $source
      */
-    public function __construct(Closure $source = null)
+    public function __construct(?Closure $source = null)
     {
         $this->source = $source;
     }

--- a/src/Toolkit/Identifiers/LazyListOfStringIds.php
+++ b/src/Toolkit/Identifiers/LazyListOfStringIds.php
@@ -29,7 +29,7 @@ final class LazyListOfStringIds implements LazyList
      *
      * @param Closure(): Generator<StringId>|null $source
      */
-    public function __construct(Closure $source = null)
+    public function __construct(?Closure $source = null)
     {
         $this->source = $source;
     }

--- a/src/Toolkit/Identifiers/LazyListOfUuids.php
+++ b/src/Toolkit/Identifiers/LazyListOfUuids.php
@@ -30,7 +30,7 @@ final class LazyListOfUuids implements LazyList
      *
      * @param Closure(): Generator<Uuid>|null $source
      */
-    public function __construct(Closure $source = null)
+    public function __construct(?Closure $source = null)
     {
         $this->source = $source;
     }

--- a/src/Toolkit/Identifiers/UuidFactory.php
+++ b/src/Toolkit/Identifiers/UuidFactory.php
@@ -34,7 +34,7 @@ final class UuidFactory implements IUuidFactory
      *
      * @param BaseUuidFactory|null $factory
      */
-    public function __construct(BaseUuidFactory $factory = null)
+    public function __construct(?BaseUuidFactory $factory = null)
     {
         $this->baseFactory = $factory ?? BaseUuid::getFactory();
     }

--- a/src/Toolkit/Pipeline/PipelineBuilder.php
+++ b/src/Toolkit/Pipeline/PipelineBuilder.php
@@ -68,7 +68,7 @@ final class PipelineBuilder implements IPipelineBuilder
     /**
      * @inheritDoc
      */
-    public function build(Processor $processor = null): Pipeline
+    public function build(?Processor $processor = null): Pipeline
     {
         return new Pipeline($processor, $this->stages);
     }

--- a/src/Toolkit/Result/FailedResultException.php
+++ b/src/Toolkit/Result/FailedResultException.php
@@ -27,7 +27,7 @@ class FailedResultException extends RuntimeException implements ContextProvider
     public function __construct(
         private readonly Result $result,
         int $code = 0,
-        Throwable $previous = null,
+        ?Throwable $previous = null,
     ) {
         assert($result->didFail(), 'Expecting a failed result.');
         parent::__construct($result->error() ?? '', $code, $previous);

--- a/tests/Unit/Domain/TestEntityWithNullableId.php
+++ b/tests/Unit/Domain/TestEntityWithNullableId.php
@@ -24,7 +24,7 @@ class TestEntityWithNullableId implements Entity
      *
      * @param Identifier|null $id
      */
-    public function __construct(Identifier $id = null)
+    public function __construct(?Identifier $id = null)
     {
         $this->id = $id;
     }


### PR DESCRIPTION
This PR adds PHP 8.4 to the automated tests executed via Github actions.