### PR TITLE
Feature: separate out command queuing to a command queuer driving port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,22 @@ All notable changes to this project will be documented in this file. This projec
 
 ## Unreleased
 
+### Added
+
+- Commands can now be queued by the presentation and delivery layer via the `CommandQueuer` port. Refer to the command
+  documentation for details.
+
 ### Changed
 
 - **BREAKING** Moved the `Message`, `Command`, `Query`, and `IntegrationEvent` interfaces to the `Toolkit\Messages`
   namespace. This is to make it clearer that these are part of the toolkit, not the application or infrastructure
   layers. It matches the `Result` and `Error` interfaces that are already in the `Toolkit\Result` namespace. I.e.
   now the toolkit contains both the input and output interfaces.
+
+### Removed
+
+- **BREAKING** The `CommandDispatcher` driving port no longer has a `queue()` method. Use the new `CommandQueuer` port
+  instead.
 
 ## [2.0.0] - 2024-12-07
 

--- a/docs/guide/application/commands.md
+++ b/docs/guide/application/commands.md
@@ -123,6 +123,8 @@ a query to retrieve the state of the newly created entity, if desired.
 To allow the _outside world_ to execute commands, our bounded context must expose a _command bus_ as a driving port.
 Although there is a _generic_ command bus interface, our bounded context needs to expose its _specific_ command bus.
 
+### Command Bus Port
+
 We do this by defining an interface in our application's driving ports.
 
 ```php
@@ -304,23 +306,105 @@ Everything else - how your bounded context processes and responds to the action 
 implementation detail_ of your domain.
 :::
 
+## Command Queuer
+
+The command bus dispatches the bounded context's logic immediately via a command handler. Or in other words - commands
+are dispatched synchronously. But what happens if the presentation and delivery layer does not need to wait for the
+result of the command being dispatched, and instead wants the command to be handled in a non-blocking way?
+
+In this scenario, the presentation and delivery layer would need to queue the command for asynchronous processing.
+It would do this via a _command queuer_, which is provided by your bounded context as a driving port.
+
+:::tip
+For more information on asynchronous processing patterns, see
+the [Asynchronous Processing chapter.](./asynchronous-processing.md)
+:::
+
+### Command Queuer Port
+
+To allow the _outside world_ to queue commands, our bounded context must expose a _command queuer_ as a driving port.
+Although there is a _generic_ command queuer interface, our bounded context needs to expose its _specific_ command
+queuer.
+
+We do this by defining an interface in our application's driving ports.
+
+```php
+namespace App\Modules\EventManagement\Application\Ports\Driving;
+
+use CloudCreativity\Modules\Application\Ports\Driving\CommandQueuer as ICommandQueuer;
+
+interface CommandQueuer extends ICommandQueuer
+{
+}
+```
+
+And then our implementation is as follows:
+
+```php
+namespace App\Modules\EventManagement\Application\Bus;
+
+use App\Modules\EventManagement\Application\Ports\Driving\CommandQueuer as Port;
+use App\Modules\EventManagement\Application\Ports\Driven\Queue;
+use CloudCreativity\Modules\Application\Bus\CommandQueuer as Queuer;
+
+final class CommandQueuer extends Queuer implements Port
+{
+    public function __construct(Queue $queue)
+    {
+        parent::__construct($queue);
+    }
+}
+```
+
+Notice that the command queuer dependency injects the specific queue instance for this bounded context - which is a
+driven port. This is because it expects to queue commands not on _any_ queue, but on the _specific_ queue for this
+bounded context. I.e. it follows the encapsulation principle.
+
+See the [Queue chapter](../infrastructure/queues.md) for more information on how to implement a queue.
+
+### Creating a Command Queuer
+
+Creating a command queuer is simple, as it is just a thin wrapper around the queue - i.e. it immediately hands off to a
+driven port. This is because queuing a command is an infrastructure concern.
+
+```php
+namespace App\Modules\EventManagement\Application\Bus;
+
+use App\Modules\EventManagement\Application\Ports\Driving\CommandQueuer as CommandQueuerPort;
+use App\Modules\EventManagement\Application\Ports\Driven\DependencyInjection\ExternalDependencies;
+
+final class CommandBusProvider
+{
+    public function __construct(
+        private readonly ExternalDependencies $dependencies,
+    ) {
+    }
+
+    public function getCommandQueuer(): CommandQueuerPort
+    {
+        return new CommandQueuer(
+            queue: $this->dependencies->getQueue(),
+        );
+    }
+}
+```
+
+:::tip
+The queue supports middleware to add cross-cutting concerns, such as logging. This means there is no need to add any
+middleware to the command queuer.
+:::
+
 ### Queuing Commands
 
-The `dispatch()` method executes the bounded context's logic immediately via a command handler. Or in other words -
-commands are dispatched synchronously. But what happens if the presentation and delivery layer does not need to wait
-for the result of the command being dispatched, and instead wants the command to be handled in a non-blocking way?
-
-In this scenario, the presentation and delivery layer can choose to queue the command for asynchronous processing. To
-indicate that a command should be queued, the `queue()` method is used instead of the `dispatch()` method.
-
-This can be used to execute a command in a non-blocking way. For example, our controller implementation could be
-updated to return a `202 Accepted` response to indicate the command has been queued:
+The command queuer can be used to execute a command in a non-blocking way. For example, our controller implementation
+from earlier in this chapter could be updated to return a `202 Accepted` response to indicate the command has been
+queued:
 
 ```php
 namespace App\Http\Controllers\Api\Attendees;
 
 use App\Modules\EventManagement\Application\{
-    Ports\Driving\CommandBus,
+    Ports\Driving\CommandQueuer,
     UseCases\Commands\CancelAttendeeTicket\CancelAttendeeTicketCommand,
 };
 use CloudCreativity\Modules\Toolkit\Identifiers\IntegerId;
@@ -331,7 +415,7 @@ class CancellationController extends Controller
 {
     public function __invoke(
         Request $request,
-        CommandBus $bus,
+        CommandQueuer $bus,
         string $attendeeId,
     ) {
         $validated = $request->validate([
@@ -351,9 +435,6 @@ class CancellationController extends Controller
     }
 }
 ```
-
-To allow commands to be queued, you **must** provide a queue factory to the command bus when creating it. This topic is
-covered in the [Queues chapter](../infrastructure/queues.md#queue-port).
 
 ## Middleware
 

--- a/docs/guide/infrastructure/queues.md
+++ b/docs/guide/infrastructure/queues.md
@@ -1,8 +1,10 @@
 # Queues
 
-As described in the [Asynchronous Processing chapter](../application/asynchronous-processing), our command bus allows
-you to queue commands for asynchronous dispatch. To do this, you need to provide a queue adapter to the command bus.
-This adapter handles pushing the command onto a queue, and dispatching the command when it is pulled from the queue.
+As described in the [Asynchronous Processing chapter](../application/asynchronous-processing), your application layer
+can allow commands to be queued via a command queuer driving port. Additionally, it may also choose to implement some
+internal processes as internal commands that are executed asynchronously. 
+
+To do either (or both!), you need to define a queue driven port. The adapter implementation then handles pushing commands onto a queue, and dispatching the command when it is pulled from the queue.
 
 We provide several queue adapters that you can use. These are designed to be simple to use and allow you to plug into
 any PHP queue implementation that you choose to use. This chapter describes these queue implementations.
@@ -24,19 +26,9 @@ interface Queue extends Port
 }
 ```
 
-This port is injected into a command bus via a closure factory that ensures the instantiation of the queue adapter is
-lazy. For example:
+If you have a command queuer driving port, you will need to inject your queue adapter into the command queuer. See the [command queuer documentation](../application/commands.md#command-queuer) for examples. 
 
-```php
-$bus = new CommandBus(
-    handlers: $handlers = new CommandHandlerContainer(),
-    middleware: $middleware = new PipeContainer(),
-    queue: fn() => $this->dependencies->getQueue(),
-);
-```
-
-This allows the application layer to push commands onto the queue. When pulling commands from the queue, your queue
-adapter will need to dispatch the command to the command bus.
+This allows the presentation and delivery layer to asynchronously dispatch commands. When pulling commands from the queue, your queue adapter will need to dispatch the command to the command bus.
 
 We provide two concrete classes that allow you to push work onto a queue via your preferred PHP implementation. If
 neither of these work for you, you can instead write a queue that implements the above interface.
@@ -45,12 +37,11 @@ neither of these work for you, you can instead write a queue that implements the
 
 The [asynchronous processing chapter](../application/asynchronous-processing) introduces the concept of _internal_
 commands. These are commands that are not exposed as use cases of your bounded context. Instead they are used to split
-long running or complex work up into smaller write operations (commands) that are sequenced via a workflow.
+long-running or complex work up into smaller write operations (commands) that are sequenced via a workflow.
 
-If you have an internal command bus, you will need to provide a separate queue port for these commands. This is because
-the internal command bus will have its own queue, that dispatches internal command messages to the internal command bus.
+If you have an internal command bus, you can provide a separate queue port for these commands. This segregates internal commands to a separate queue, which is advantageous to separate the concerns of commands that are use cases of your bounded context (driving ports) or internal to the application layer.
 
-In this scenario, define another driven port in your application layer:
+In this scenario, define another driven port:
 
 ```php
 namespace App\Modules\EventManagement\Application\Ports\Driven\Queue;
@@ -62,15 +53,7 @@ interface InternalQueue extends Port
 }
 ```
 
-And then ensure the adapter of this internal port is injected into your internal command bus:
-
-```php
-$bus = new InternalCommandBus(
-    handlers: $handlers = new CommandHandlerContainer(),
-    middleware: $middleware = new PipeContainer(),
-    queue: fn() => $this->dependencies->getInternalQueue(),
-);
-```
+Then wherever your application layer needs to queue an internal command, it can do this via the internal queue port.
 
 ## Closure Queuing
 

--- a/src/Application/Bus/CommandDispatcher.php
+++ b/src/Application/Bus/CommandDispatcher.php
@@ -12,24 +12,16 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Application\Bus;
 
-use Closure;
 use CloudCreativity\Modules\Contracts\Application\Bus\CommandHandlerContainer;
-use CloudCreativity\Modules\Contracts\Application\Ports\Driven\Queue;
 use CloudCreativity\Modules\Contracts\Application\Ports\Driving\CommandDispatcher as ICommandDispatcher;
 use CloudCreativity\Modules\Contracts\Toolkit\Messages\Command;
 use CloudCreativity\Modules\Contracts\Toolkit\Pipeline\PipeContainer;
 use CloudCreativity\Modules\Contracts\Toolkit\Result\Result;
 use CloudCreativity\Modules\Toolkit\Pipeline\MiddlewareProcessor;
 use CloudCreativity\Modules\Toolkit\Pipeline\PipelineBuilder;
-use RuntimeException;
 
 class CommandDispatcher implements ICommandDispatcher
 {
-    /**
-     * @var null|Queue|Closure(): Queue
-     */
-    private Queue|Closure|null $queue;
-
     /**
      * @var array<string|callable>
      */
@@ -40,14 +32,11 @@ class CommandDispatcher implements ICommandDispatcher
      *
      * @param CommandHandlerContainer $handlers
      * @param PipeContainer|null $middleware
-     * @param null|Closure(): Queue $queue
      */
     public function __construct(
         private readonly CommandHandlerContainer $handlers,
         private readonly ?PipeContainer $middleware = null,
-        ?Closure $queue = null,
     ) {
-        $this->queue = $queue;
     }
 
     /**
@@ -79,24 +68,6 @@ class CommandDispatcher implements ICommandDispatcher
         assert($result instanceof Result, 'Expecting pipeline to return a result object.');
 
         return $result;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function queue(Command $command): void
-    {
-        if ($this->queue === null) {
-            throw new RuntimeException(
-                'Commands cannot be queued because the command dispatcher has not been given a queue factory.',
-            );
-        }
-
-        if ($this->queue instanceof Closure) {
-            $this->queue = ($this->queue)();
-        }
-
-        $this->queue->push($command);
     }
 
     /**

--- a/src/Application/Bus/CommandQueuer.php
+++ b/src/Application/Bus/CommandQueuer.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Application\Bus;
+
+use CloudCreativity\Modules\Contracts\Application\Ports\Driven\Queue;
+use CloudCreativity\Modules\Contracts\Application\Ports\Driving\CommandQueuer as ICommandQueuer;
+use CloudCreativity\Modules\Contracts\Toolkit\Messages\Command;
+
+class CommandQueuer implements ICommandQueuer
+{
+    /**
+     * CommandQueuer constructor.
+     *
+     * @param Queue $queue
+     */
+    public function __construct(private readonly Queue $queue)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function queue(Command $command): void
+    {
+        $this->queue->push($command);
+    }
+}

--- a/src/Contracts/Application/Ports/Driving/CommandQueuer.php
+++ b/src/Contracts/Application/Ports/Driving/CommandQueuer.php
@@ -13,15 +13,14 @@ declare(strict_types=1);
 namespace CloudCreativity\Modules\Contracts\Application\Ports\Driving;
 
 use CloudCreativity\Modules\Contracts\Toolkit\Messages\Command;
-use CloudCreativity\Modules\Contracts\Toolkit\Result\Result;
 
-interface CommandDispatcher
+interface CommandQueuer
 {
     /**
-     * Dispatch the given command.
+     * Queue a command for asynchronous dispatching.
      *
      * @param Command $command
-     * @return Result<mixed>
+     * @return void
      */
-    public function dispatch(Command $command): Result;
+    public function queue(Command $command): void;
 }

--- a/tests/Unit/Application/Bus/CommandQueuerTest.php
+++ b/tests/Unit/Application/Bus/CommandQueuerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Tests\Unit\Application\Bus;
+
+use CloudCreativity\Modules\Application\Bus\CommandQueuer;
+use CloudCreativity\Modules\Contracts\Application\Ports\Driven\Queue;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CommandQueuerTest extends TestCase
+{
+    /**
+     * @var MockObject&Queue
+     */
+    private Queue&MockObject $queue;
+
+    /**
+     * @var CommandQueuer
+     */
+    private CommandQueuer $queuer;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->queuer = new CommandQueuer(
+            $this->queue = $this->createMock(Queue::class),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        unset($this->queue, $this->queuer);
+        parent::tearDown();
+    }
+
+    /**
+     * @return void
+     */
+    public function test(): void
+    {
+        $this->queue
+            ->expects($this->once())
+            ->method('push')
+            ->with($this->identicalTo($command = new TestCommand()));
+
+        $this->queuer->queue($command);
+    }
+}


### PR DESCRIPTION
Previously, the command bus exposed a `queue()` method for asynchronously dispatching commands.

This PR separates that out to a _command queuer_ driving port. This is better because it means the application layer only exposes command queuing to the presentation and delivery layer if it supports it.

Additionally, it makes more sense for the queuing of internal commands. Now for internal work, the application layer just pushes commands directly to the queue driven port. An internal command bus can then be used for dispatching those queued commands - but importantly, this command bus can actually be defined as a driven port, which makes more sense as queuing commands requires infrastructure and therefore should only exist as a driven port if it is not exposed to the outside world.