### PR TITLE
Fix: allow is entity trait to be used on readonly class as intended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file. This projec
 
 ## Unreleased
 
+### Fixed
+
+- Make the `id` property on the `IsEntity` trait readonly. This is considered non-breaking because the `IsEntity` trait
+  is expected to be used on an entity that always has an identifier, so the id should be set via the constructor. This
+  fixes a bug where the trait could not be used on a readonly class.
+
 ## [3.1.0] - 2025-02-15
 
 ### Added

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,4 +3,6 @@ parameters:
     paths:
         - src
         - tests
+    excludePaths:
+        - tests/Unit/Domain/TestReadOnlyEntity.php
     treatPhpDocTypesAsCertain: false

--- a/pint.json
+++ b/pint.json
@@ -7,7 +7,7 @@
         },
         "nullable_type_declaration": true
     },
-    "exclude": [
+    "notPath": [
         "tests/Unit/Domain/TestReadOnlyEntity.php"
     ]
 }

--- a/pint.json
+++ b/pint.json
@@ -6,5 +6,8 @@
             "elements": ["arguments", "arrays", "match", "parameters"]
         },
         "nullable_type_declaration": true
-    }
+    },
+    "exclude": [
+        "tests/Unit/Domain/TestReadOnlyEntity.php"
+    ]
 }

--- a/src/Domain/IsEntity.php
+++ b/src/Domain/IsEntity.php
@@ -20,7 +20,7 @@ trait IsEntity
     /**
      * @var Identifier
      */
-    private Identifier $id;
+    private readonly Identifier $id;
 
     /**
      * @inheritDoc

--- a/tests/Unit/Domain/EntityTest.php
+++ b/tests/Unit/Domain/EntityTest.php
@@ -15,6 +15,7 @@ namespace CloudCreativity\Modules\Tests\Unit\Domain;
 use CloudCreativity\Modules\Contracts\Domain\Entity;
 use CloudCreativity\Modules\Contracts\Toolkit\Identifiers\Identifier;
 use CloudCreativity\Modules\Toolkit\Identifiers\Guid;
+use CloudCreativity\Modules\Toolkit\Identifiers\IntegerId;
 use PHPUnit\Framework\TestCase;
 
 class EntityTest extends TestCase
@@ -96,5 +97,18 @@ class EntityTest extends TestCase
 
         $this->assertFalse($a->is($b));
         $this->assertTrue($a->isNot($b));
+    }
+
+    public function testItCanUseTraitOnReadonlyClass(): void
+    {
+        if (PHP_VERSION_ID < 80200) {
+            $this->markTestSkipped('This test requires PHP 8.2 or higher.');
+        }
+
+        $id = new IntegerId(123);
+        $entity = new TestReadOnlyEntity($id, 'Bob');
+
+        $this->assertSame($id, $entity->getId());
+        $this->assertSame('Bob', $entity->getName());
     }
 }

--- a/tests/Unit/Domain/TestReadOnlyEntity.php
+++ b/tests/Unit/Domain/TestReadOnlyEntity.php
@@ -16,6 +16,9 @@ use CloudCreativity\Modules\Contracts\Domain\Entity;
 use CloudCreativity\Modules\Contracts\Toolkit\Identifiers\Identifier;
 use CloudCreativity\Modules\Domain\IsEntity;
 
+/**
+ * @TODO remove when dropping PHP 8.1 and update `TestEntity` to be `readonly`.
+ */
 final readonly class TestReadOnlyEntity implements Entity
 {
     use IsEntity;

--- a/tests/Unit/Domain/TestReadOnlyEntity.php
+++ b/tests/Unit/Domain/TestReadOnlyEntity.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright 2025 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace CloudCreativity\Modules\Tests\Unit\Domain;
+
+use CloudCreativity\Modules\Contracts\Domain\Entity;
+use CloudCreativity\Modules\Contracts\Toolkit\Identifiers\Identifier;
+use CloudCreativity\Modules\Domain\IsEntity;
+
+final readonly class TestReadOnlyEntity implements Entity
+{
+    use IsEntity;
+
+    /**
+     * TestReadOnlyEntity constructor
+     *
+     * @param Identifier $id
+     * @param string $name
+     */
+    public function __construct(Identifier $id, private string $name)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}


### PR DESCRIPTION
The `IsEntity` trait could not be used on a readonly class, because the `id` property was not marked as readonly.

This is a fix, because this trait is intended for use on an entity that always has an identifier. Therefore, the identifier should be set via the constructor - not lazily.