### PR TITLE
refactor: enforce final and make extendable classes abstract

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -7,6 +7,7 @@
         "binary_operator_spaces": true,
         "clean_namespace": true,
         "declare_strict_types": true,
+        "final_class": true,
         "list_syntax": true,
         "new_expression_parentheses": true,
         "no_empty_phpdoc": true,

--- a/src/Application/ApplicationException.php
+++ b/src/Application/ApplicationException.php
@@ -12,8 +12,9 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Application;
 
+use CloudCreativity\Modules\Contracts\Application\ApplicationException as IApplicationException;
 use RuntimeException;
 
-class ApplicationException extends RuntimeException
+final class ApplicationException extends RuntimeException implements IApplicationException
 {
 }

--- a/src/Application/Bus/AbortOnFailureException.php
+++ b/src/Application/Bus/AbortOnFailureException.php
@@ -12,8 +12,25 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Application\Bus;
 
-use CloudCreativity\Modules\Toolkit\Result\FailedResultException;
+use CloudCreativity\Modules\Contracts\Toolkit\Result\FailedResultException;
+use CloudCreativity\Modules\Contracts\Toolkit\Result\Result;
+use RuntimeException;
 
-final class AbortOnFailureException extends FailedResultException
+/**
+ * @internal
+ */
+final class AbortOnFailureException extends RuntimeException implements FailedResultException
 {
+    /**
+     * @param Result<mixed> $result
+     */
+    public function __construct(private readonly Result $result)
+    {
+        parent::__construct();
+    }
+
+    public function getResult(): Result
+    {
+        return $this->result;
+    }
 }

--- a/src/Application/Bus/CommandQueuer.php
+++ b/src/Application/Bus/CommandQueuer.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Contracts\Application\Ports\Queue;
 use CloudCreativity\Modules\Contracts\Bus\CommandQueuer as ICommandQueuer;
 use CloudCreativity\Modules\Contracts\Messaging\Command;
 
-class CommandQueuer implements ICommandQueuer
+final class CommandQueuer implements ICommandQueuer
 {
     public function __construct(private readonly Queue $queue)
     {

--- a/src/Application/Bus/CommandQueuer.php
+++ b/src/Application/Bus/CommandQueuer.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Contracts\Application\Ports\Queue;
 use CloudCreativity\Modules\Contracts\Bus\CommandQueuer as ICommandQueuer;
 use CloudCreativity\Modules\Contracts\Messaging\Command;
 
-final class CommandQueuer implements ICommandQueuer
+abstract class CommandQueuer implements ICommandQueuer
 {
     public function __construct(private readonly Queue $queue)
     {

--- a/src/Application/DomainEventDispatching/DeferredDispatcher.php
+++ b/src/Application/DomainEventDispatching/DeferredDispatcher.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Contracts\Application\DomainEventDispatching\Deferre
 use CloudCreativity\Modules\Contracts\Domain\Events\DomainEvent;
 use CloudCreativity\Modules\Contracts\Domain\Events\OccursImmediately;
 
-class DeferredDispatcher extends Dispatcher implements IDeferredDispatcher
+abstract class DeferredDispatcher extends Dispatcher implements IDeferredDispatcher
 {
     /**
      * @var array<DomainEvent>

--- a/src/Application/DomainEventDispatching/Dispatcher.php
+++ b/src/Application/DomainEventDispatching/Dispatcher.php
@@ -26,7 +26,7 @@ use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use ReflectionClass;
 
-class Dispatcher implements DomainEventDispatcher
+abstract class Dispatcher implements DomainEventDispatcher
 {
     private readonly IListenerContainer $listeners;
 

--- a/src/Application/DomainEventDispatching/UnitOfWorkAwareDispatcher.php
+++ b/src/Application/DomainEventDispatching/UnitOfWorkAwareDispatcher.php
@@ -20,7 +20,7 @@ use CloudCreativity\Modules\Contracts\Toolkit\Pipeline\PipeContainer;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
-class UnitOfWorkAwareDispatcher extends Dispatcher
+abstract class UnitOfWorkAwareDispatcher extends Dispatcher
 {
     public function __construct(
         private readonly UnitOfWorkManager $unitOfWorkManager,

--- a/src/Bus/BusException.php
+++ b/src/Bus/BusException.php
@@ -14,6 +14,6 @@ namespace CloudCreativity\Modules\Bus;
 
 use RuntimeException;
 
-class BusException extends RuntimeException
+final class BusException extends RuntimeException
 {
 }

--- a/src/Bus/BusException.php
+++ b/src/Bus/BusException.php
@@ -12,8 +12,9 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Bus;
 
+use CloudCreativity\Modules\Contracts\Bus\BusException as IBusException;
 use RuntimeException;
 
-final class BusException extends RuntimeException
+final class BusException extends RuntimeException implements IBusException
 {
 }

--- a/src/Bus/CommandDispatcher.php
+++ b/src/Bus/CommandDispatcher.php
@@ -23,7 +23,7 @@ use CloudCreativity\Modules\Toolkit\Pipeline\Through;
 use Psr\Container\ContainerInterface;
 use ReflectionClass;
 
-class CommandDispatcher implements ICommandDispatcher
+abstract class CommandDispatcher implements ICommandDispatcher
 {
     private readonly ICommandHandlerContainer $handlers;
 

--- a/src/Bus/InboundEventDispatcher.php
+++ b/src/Bus/InboundEventDispatcher.php
@@ -21,7 +21,7 @@ use CloudCreativity\Modules\Toolkit\Pipeline\PipelineBuilder;
 use CloudCreativity\Modules\Toolkit\Pipeline\Through;
 use Psr\Container\ContainerInterface;
 
-class InboundEventDispatcher implements IInboundEventDispatcher
+abstract class InboundEventDispatcher implements IInboundEventDispatcher
 {
     private readonly IEventHandlerContainer $handlers;
 

--- a/src/Bus/QueryDispatcher.php
+++ b/src/Bus/QueryDispatcher.php
@@ -23,7 +23,7 @@ use CloudCreativity\Modules\Toolkit\Pipeline\Through;
 use Psr\Container\ContainerInterface;
 use ReflectionClass;
 
-class QueryDispatcher implements IQueryDispatcher
+abstract class QueryDispatcher implements IQueryDispatcher
 {
     private readonly IQueryHandlerContainer $handlers;
 

--- a/src/Contracts/Application/ApplicationException.php
+++ b/src/Contracts/Application/ApplicationException.php
@@ -10,13 +10,10 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Tests\Unit\Application\Bus;
+namespace CloudCreativity\Modules\Contracts\Application;
 
-use CloudCreativity\Modules\Contracts\Messaging\Command;
+use Throwable;
 
-final class TestCommand implements Command
+interface ApplicationException extends Throwable
 {
-    public function __construct(public bool $fail = false)
-    {
-    }
 }

--- a/src/Contracts/Bus/BusException.php
+++ b/src/Contracts/Bus/BusException.php
@@ -10,11 +10,10 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Toolkit;
+namespace CloudCreativity\Modules\Contracts\Bus;
 
-use CloudCreativity\Modules\Contracts\Toolkit\ContractException as IContractException;
-use LogicException;
+use Throwable;
 
-final class ContractException extends LogicException implements IContractException
+interface BusException extends Throwable
 {
 }

--- a/src/Contracts/Infrastructure/InfrastructureException.php
+++ b/src/Contracts/Infrastructure/InfrastructureException.php
@@ -10,13 +10,10 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Tests\Unit\Application\Bus;
+namespace CloudCreativity\Modules\Contracts\Infrastructure;
 
-use CloudCreativity\Modules\Contracts\Messaging\Command;
+use Throwable;
 
-final class TestCommand implements Command
+interface InfrastructureException extends Throwable
 {
-    public function __construct(public bool $fail = false)
-    {
-    }
 }

--- a/src/Contracts/Toolkit/ContractException.php
+++ b/src/Contracts/Toolkit/ContractException.php
@@ -10,11 +10,10 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Toolkit;
+namespace CloudCreativity\Modules\Contracts\Toolkit;
 
-use CloudCreativity\Modules\Contracts\Toolkit\ContractException as IContractException;
-use LogicException;
+use Throwable;
 
-final class ContractException extends LogicException implements IContractException
+interface ContractException extends Throwable
 {
 }

--- a/src/Contracts/Toolkit/Result/FailedResultException.php
+++ b/src/Contracts/Toolkit/Result/FailedResultException.php
@@ -10,13 +10,14 @@
 
 declare(strict_types=1);
 
-namespace CloudCreativity\Modules\Tests\Unit\Application\Bus;
+namespace CloudCreativity\Modules\Contracts\Toolkit\Result;
 
-use CloudCreativity\Modules\Contracts\Messaging\Command;
+use Throwable;
 
-final class TestCommand implements Command
+interface FailedResultException extends Throwable
 {
-    public function __construct(public bool $fail = false)
-    {
-    }
+    /**
+     * @return Result<mixed>
+     */
+    public function getResult(): Result;
 }

--- a/src/Infrastructure/InfrastructureException.php
+++ b/src/Infrastructure/InfrastructureException.php
@@ -12,8 +12,9 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Infrastructure;
 
+use CloudCreativity\Modules\Contracts\Infrastructure\InfrastructureException as IInfrastructureException;
 use RuntimeException;
 
-class InfrastructureException extends RuntimeException
+final class InfrastructureException extends RuntimeException implements IInfrastructureException
 {
 }

--- a/src/Infrastructure/OutboundEventBus/ClosurePublisher.php
+++ b/src/Infrastructure/OutboundEventBus/ClosurePublisher.php
@@ -23,7 +23,7 @@ use CloudCreativity\Modules\Toolkit\Pipeline\Through;
 use Psr\Container\ContainerInterface;
 use ReflectionClass;
 
-class ClosurePublisher implements OutboundEventPublisher
+abstract class ClosurePublisher implements OutboundEventPublisher
 {
     private readonly ?IPipeContainer $middleware;
 

--- a/src/Infrastructure/OutboundEventBus/ComponentPublisher.php
+++ b/src/Infrastructure/OutboundEventBus/ComponentPublisher.php
@@ -23,7 +23,7 @@ use CloudCreativity\Modules\Toolkit\Pipeline\Through;
 use Psr\Container\ContainerInterface;
 use ReflectionClass;
 
-class ComponentPublisher implements OutboundEventPublisher
+abstract class ComponentPublisher implements OutboundEventPublisher
 {
     private readonly IPublisherHandlerContainer $handlers;
 

--- a/src/Infrastructure/Queue/ClosureQueue.php
+++ b/src/Infrastructure/Queue/ClosureQueue.php
@@ -23,7 +23,7 @@ use CloudCreativity\Modules\Toolkit\Pipeline\Through;
 use Psr\Container\ContainerInterface;
 use ReflectionClass;
 
-class ClosureQueue implements Queue
+abstract class ClosureQueue implements Queue
 {
     private readonly ?IPipeContainer $middleware;
 

--- a/src/Infrastructure/Queue/ComponentQueue.php
+++ b/src/Infrastructure/Queue/ComponentQueue.php
@@ -23,7 +23,7 @@ use CloudCreativity\Modules\Toolkit\Pipeline\Through;
 use Psr\Container\ContainerInterface;
 use ReflectionClass;
 
-class ComponentQueue implements Queue
+abstract class ComponentQueue implements Queue
 {
     private readonly IEnqueuerContainer $enqueuers;
 

--- a/src/Testing/FakeDomainEventDispatcher.php
+++ b/src/Testing/FakeDomainEventDispatcher.php
@@ -24,7 +24,7 @@ use LogicException;
  * @implements ArrayAccess<int, DomainEvent>
  * @implements IteratorAggregate<int, DomainEvent>
  */
-class FakeDomainEventDispatcher implements DomainEventDispatcher, Countable, ArrayAccess, IteratorAggregate
+abstract class FakeDomainEventDispatcher implements DomainEventDispatcher, Countable, ArrayAccess, IteratorAggregate
 {
     /**
      * @var list<DomainEvent>

--- a/src/Testing/FakeOutboundEventPublisher.php
+++ b/src/Testing/FakeOutboundEventPublisher.php
@@ -24,7 +24,7 @@ use LogicException;
  * @implements ArrayAccess<int, IntegrationEvent>
  * @implements IteratorAggregate<int, IntegrationEvent>
  */
-class FakeOutboundEventPublisher implements OutboundEventPublisher, Countable, ArrayAccess, IteratorAggregate
+abstract class FakeOutboundEventPublisher implements OutboundEventPublisher, Countable, ArrayAccess, IteratorAggregate
 {
     /**
      * @var list<IntegrationEvent>

--- a/src/Testing/FakeQueue.php
+++ b/src/Testing/FakeQueue.php
@@ -24,7 +24,7 @@ use LogicException;
  * @implements ArrayAccess<int, Command>
  * @implements IteratorAggregate<int, Command>
  */
-class FakeQueue implements Queue, Countable, ArrayAccess, IteratorAggregate
+abstract class FakeQueue implements Queue, Countable, ArrayAccess, IteratorAggregate
 {
     /**
      * @var list<Command>

--- a/src/Toolkit/ContractException.php
+++ b/src/Toolkit/ContractException.php
@@ -14,6 +14,6 @@ namespace CloudCreativity\Modules\Toolkit;
 
 use LogicException;
 
-class ContractException extends LogicException
+final class ContractException extends LogicException
 {
 }

--- a/src/Toolkit/Result/ContextualResult.php
+++ b/src/Toolkit/Result/ContextualResult.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Contracts\Toolkit\Contextual;
 use CloudCreativity\Modules\Contracts\Toolkit\Result\Error;
 use CloudCreativity\Modules\Contracts\Toolkit\Result\Result;
 
-readonly class ContextualResult implements Contextual
+final readonly class ContextualResult implements Contextual
 {
     /**
      * @param Result<mixed> $result

--- a/src/Toolkit/Result/FailedResultException.php
+++ b/src/Toolkit/Result/FailedResultException.php
@@ -12,13 +12,14 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Toolkit\Result;
 
+use CloudCreativity\Modules\Contracts\Toolkit\Result\FailedResultException as IFailedResultException;
 use CloudCreativity\Modules\Contracts\Toolkit\Result\Result;
 use RuntimeException;
 use Throwable;
 
 use function CloudCreativity\Modules\Toolkit\enum_string;
 
-class FailedResultException extends RuntimeException
+final class FailedResultException extends RuntimeException implements IFailedResultException
 {
     /**
      * @param Result<mixed> $result

--- a/tests/Integration/Application/DomainEventDispatching/MathDomainEventDispatcherTest.php
+++ b/tests/Integration/Application/DomainEventDispatching/MathDomainEventDispatcherTest.php
@@ -17,7 +17,7 @@ use CloudCreativity\Modules\Application\UnitOfWork\UnitOfWorkManager;
 use CloudCreativity\Modules\Testing\FakeContainer;
 use PHPUnit\Framework\TestCase;
 
-class MathDomainEventDispatcherTest extends TestCase
+final class MathDomainEventDispatcherTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Integration/Bus/MathCommandBusTest.php
+++ b/tests/Integration/Bus/MathCommandBusTest.php
@@ -18,7 +18,7 @@ use CloudCreativity\Modules\Bus\Middleware\LogMessageDispatch;
 use CloudCreativity\Modules\Testing\FakeContainer;
 use PHPUnit\Framework\TestCase;
 
-class MathCommandBusTest extends TestCase
+final class MathCommandBusTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Integration/Bus/MathEventBusTest.php
+++ b/tests/Integration/Bus/MathEventBusTest.php
@@ -18,7 +18,7 @@ use CloudCreativity\Modules\Bus\Middleware\LogMessageDispatch;
 use CloudCreativity\Modules\Testing\FakeContainer;
 use PHPUnit\Framework\TestCase;
 
-class MathEventBusTest extends TestCase
+final class MathEventBusTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Integration/Bus/MathQueryBusTest.php
+++ b/tests/Integration/Bus/MathQueryBusTest.php
@@ -17,7 +17,7 @@ use CloudCreativity\Modules\Bus\Middleware\LogMessageDispatch;
 use CloudCreativity\Modules\Testing\FakeContainer;
 use PHPUnit\Framework\TestCase;
 
-class MathQueryBusTest extends TestCase
+final class MathQueryBusTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Integration/Infrastructure/OutboundEventBus/MathEventPublisherTest.php
+++ b/tests/Integration/Infrastructure/OutboundEventBus/MathEventPublisherTest.php
@@ -19,7 +19,7 @@ use CloudCreativity\Modules\Tests\Integration\Bus\NumbersDivided;
 use CloudCreativity\Modules\Tests\Integration\Bus\NumbersSubtracted;
 use PHPUnit\Framework\TestCase;
 
-class MathEventPublisherTest extends TestCase
+final class MathEventPublisherTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Integration/Infrastructure/OutboundEventBus/TestClosurePublisherTest.php
+++ b/tests/Integration/Infrastructure/OutboundEventBus/TestClosurePublisherTest.php
@@ -17,7 +17,7 @@ use CloudCreativity\Modules\Testing\FakeContainer;
 use CloudCreativity\Modules\Tests\Integration\Bus\NumbersAdded;
 use PHPUnit\Framework\TestCase;
 
-class TestClosurePublisherTest extends TestCase
+final class TestClosurePublisherTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Integration/Infrastructure/Queue/MathQueueTest.php
+++ b/tests/Integration/Infrastructure/Queue/MathQueueTest.php
@@ -19,7 +19,7 @@ use CloudCreativity\Modules\Tests\Integration\Bus\FloorCommand;
 use CloudCreativity\Modules\Tests\Integration\Bus\MultiplyCommand;
 use PHPUnit\Framework\TestCase;
 
-class MathQueueTest extends TestCase
+final class MathQueueTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Integration/Infrastructure/Queue/TestClosureQueueTest.php
+++ b/tests/Integration/Infrastructure/Queue/TestClosureQueueTest.php
@@ -17,7 +17,7 @@ use CloudCreativity\Modules\Testing\FakeContainer;
 use CloudCreativity\Modules\Tests\Integration\Bus\AddCommand;
 use PHPUnit\Framework\TestCase;
 
-class TestClosureQueueTest extends TestCase
+final class TestClosureQueueTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Application/ApplicationExceptionTest.php
+++ b/tests/Unit/Application/ApplicationExceptionTest.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Application\ApplicationException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-class ApplicationExceptionTest extends TestCase
+final class ApplicationExceptionTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Application/Bus/CommandDispatcherTest.php
+++ b/tests/Unit/Application/Bus/CommandDispatcherTest.php
@@ -21,7 +21,7 @@ use CloudCreativity\Modules\Toolkit\Result\Result;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class CommandDispatcherTest extends TestCase
+final class CommandDispatcherTest extends TestCase
 {
     private CommandHandlerContainer&MockObject $handlers;
 
@@ -38,10 +38,10 @@ class CommandDispatcherTest extends TestCase
     {
         parent::setUp();
 
-        $this->dispatcher = new CommandDispatcher(
+        $this->dispatcher = new class (
             handlers: $this->handlers = $this->createMock(CommandHandlerContainer::class),
             middleware: $this->middleware = $this->createMock(PipeContainer::class),
-        );
+        ) extends CommandDispatcher {};
     }
 
     protected function tearDown(): void

--- a/tests/Unit/Application/Bus/CommandHandlerContainerTest.php
+++ b/tests/Unit/Application/Bus/CommandHandlerContainerTest.php
@@ -19,11 +19,11 @@ use CloudCreativity\Modules\Contracts\Messaging\Command;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-class CommandHandlerContainerTest extends TestCase
+final class CommandHandlerContainerTest extends TestCase
 {
     public function testItResolvesUsingClosureBindings(): void
     {
-        $a = new TestCommandHandler();
+        $a = new class () extends TestCommandHandler {};
         $b = $this->createStub(TestCommandHandler::class);
 
         $command1 = new class () implements Command {};
@@ -45,7 +45,7 @@ class CommandHandlerContainerTest extends TestCase
 
     public function testItResolvesViaPsrContainer(): void
     {
-        $a = new TestCommandHandler();
+        $a = new class () extends TestCommandHandler {};
         $b = $this->createStub(TestCommandHandler::class);
 
         $command1 = new class () implements Command {};

--- a/tests/Unit/Application/Bus/CommandHandlerTest.php
+++ b/tests/Unit/Application/Bus/CommandHandlerTest.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Bus\CommandHandler;
 use CloudCreativity\Modules\Toolkit\Result\Result;
 use PHPUnit\Framework\TestCase;
 
-class CommandHandlerTest extends TestCase
+final class CommandHandlerTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Application/Bus/CommandQueuerTest.php
+++ b/tests/Unit/Application/Bus/CommandQueuerTest.php
@@ -17,7 +17,7 @@ use CloudCreativity\Modules\Contracts\Application\Ports\Queue;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class CommandQueuerTest extends TestCase
+final class CommandQueuerTest extends TestCase
 {
     private MockObject&Queue $queue;
 

--- a/tests/Unit/Application/Bus/CommandQueuerTest.php
+++ b/tests/Unit/Application/Bus/CommandQueuerTest.php
@@ -27,9 +27,9 @@ final class CommandQueuerTest extends TestCase
     {
         parent::setUp();
 
-        $this->queuer = new CommandQueuer(
+        $this->queuer = new class (
             $this->queue = $this->createMock(Queue::class),
-        );
+        ) extends CommandQueuer {};
     }
 
     protected function tearDown(): void

--- a/tests/Unit/Application/Bus/Middleware/ExecuteInUnitOfWorkTest.php
+++ b/tests/Unit/Application/Bus/Middleware/ExecuteInUnitOfWorkTest.php
@@ -19,7 +19,7 @@ use CloudCreativity\Modules\Toolkit\Result\Result;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 
-class ExecuteInUnitOfWorkTest extends TestCase
+final class ExecuteInUnitOfWorkTest extends TestCase
 {
     /**
      * @var array<string>

--- a/tests/Unit/Application/Bus/Middleware/FlushDeferredEventsTest.php
+++ b/tests/Unit/Application/Bus/Middleware/FlushDeferredEventsTest.php
@@ -19,7 +19,7 @@ use CloudCreativity\Modules\Toolkit\Result\Result;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class FlushDeferredEventsTest extends TestCase
+final class FlushDeferredEventsTest extends TestCase
 {
     private DeferredDispatcher&MockObject $dispatcher;
 

--- a/tests/Unit/Application/Bus/Middleware/LogMessageDispatchTest.php
+++ b/tests/Unit/Application/Bus/Middleware/LogMessageDispatchTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
-class LogMessageDispatchTest extends TestCase
+final class LogMessageDispatchTest extends TestCase
 {
     private LoggerInterface&Stub $logger;
 

--- a/tests/Unit/Application/Bus/Middleware/SetupBeforeDispatchTest.php
+++ b/tests/Unit/Application/Bus/Middleware/SetupBeforeDispatchTest.php
@@ -20,7 +20,7 @@ use CloudCreativity\Modules\Toolkit\Result\Result;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-class SetupBeforeDispatchTest extends TestCase
+final class SetupBeforeDispatchTest extends TestCase
 {
     /**
      * @var array<string>

--- a/tests/Unit/Application/Bus/Middleware/TearDownAfterDispatchTest.php
+++ b/tests/Unit/Application/Bus/Middleware/TearDownAfterDispatchTest.php
@@ -19,7 +19,7 @@ use CloudCreativity\Modules\Toolkit\Result\Result;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-class TearDownAfterDispatchTest extends TestCase
+final class TearDownAfterDispatchTest extends TestCase
 {
     public function testItInvokesCallbackAfterSuccess(): void
     {

--- a/tests/Unit/Application/Bus/Middleware/ValidateMessageTest.php
+++ b/tests/Unit/Application/Bus/Middleware/ValidateMessageTest.php
@@ -24,7 +24,7 @@ use CloudCreativity\Modules\Toolkit\Result\ListOfErrors;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class ValidateMessageTest extends TestCase
+final class ValidateMessageTest extends TestCase
 {
     /**
      * @var MockObject&Validator

--- a/tests/Unit/Application/Bus/QueryDispatcherTest.php
+++ b/tests/Unit/Application/Bus/QueryDispatcherTest.php
@@ -21,7 +21,7 @@ use CloudCreativity\Modules\Toolkit\Result\Result;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class QueryDispatcherTest extends TestCase
+final class QueryDispatcherTest extends TestCase
 {
     /**
      * @var MockObject&QueryHandlerContainer
@@ -44,10 +44,10 @@ class QueryDispatcherTest extends TestCase
     {
         parent::setUp();
 
-        $this->dispatcher = new QueryDispatcher(
+        $this->dispatcher = new class (
             handlers: $this->handlers = $this->createMock(QueryHandlerContainer::class),
             middleware: $this->middleware = $this->createMock(PipeContainer::class),
-        );
+        ) extends QueryDispatcher {};
     }
 
     protected function tearDown(): void

--- a/tests/Unit/Application/Bus/QueryHandlerContainerTest.php
+++ b/tests/Unit/Application/Bus/QueryHandlerContainerTest.php
@@ -19,11 +19,11 @@ use CloudCreativity\Modules\Contracts\Messaging\Query;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-class QueryHandlerContainerTest extends TestCase
+final class QueryHandlerContainerTest extends TestCase
 {
     public function testItResolvesClosureBindings(): void
     {
-        $a = new TestQueryHandler();
+        $a = new class () extends TestQueryHandler {};
         $b = $this->createStub(TestQueryHandler::class);
 
         $query1 = new class () implements Query {};
@@ -45,7 +45,7 @@ class QueryHandlerContainerTest extends TestCase
 
     public function testItResolvesViaPsrContainer(): void
     {
-        $a = new TestQueryHandler();
+        $a = new class () extends TestQueryHandler {};
         $b = $this->createStub(TestQueryHandler::class);
 
         $query1 = new class () implements Query {};

--- a/tests/Unit/Application/Bus/QueryHandlerTest.php
+++ b/tests/Unit/Application/Bus/QueryHandlerTest.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Bus\QueryHandler;
 use CloudCreativity\Modules\Toolkit\Result\Result;
 use PHPUnit\Framework\TestCase;
 
-class QueryHandlerTest extends TestCase
+final class QueryHandlerTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Application/Bus/TestCommandHandler.php
+++ b/tests/Unit/Application/Bus/TestCommandHandler.php
@@ -17,7 +17,7 @@ use CloudCreativity\Modules\Contracts\Toolkit\Identifiers\Identifier;
 use CloudCreativity\Modules\Toolkit\Identifiers\Uuid;
 use CloudCreativity\Modules\Toolkit\Result\Result;
 
-class TestCommandHandler implements DispatchThroughMiddleware
+abstract class TestCommandHandler implements DispatchThroughMiddleware
 {
     /**
      * Execute the command.

--- a/tests/Unit/Application/Bus/TestQuery.php
+++ b/tests/Unit/Application/Bus/TestQuery.php
@@ -14,6 +14,6 @@ namespace CloudCreativity\Modules\Tests\Unit\Application\Bus;
 
 use CloudCreativity\Modules\Contracts\Messaging\Query;
 
-class TestQuery implements Query
+final class TestQuery implements Query
 {
 }

--- a/tests/Unit/Application/Bus/TestQueryHandler.php
+++ b/tests/Unit/Application/Bus/TestQueryHandler.php
@@ -15,7 +15,7 @@ namespace CloudCreativity\Modules\Tests\Unit\Application\Bus;
 use CloudCreativity\Modules\Contracts\Bus\DispatchThroughMiddleware;
 use CloudCreativity\Modules\Toolkit\Result\Result;
 
-class TestQueryHandler implements DispatchThroughMiddleware
+abstract class TestQueryHandler implements DispatchThroughMiddleware
 {
     /**
      * Execute the query.

--- a/tests/Unit/Application/Bus/ValidatorTest.php
+++ b/tests/Unit/Application/Bus/ValidatorTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-class ValidatorTest extends TestCase
+final class ValidatorTest extends TestCase
 {
     /**
      * @return array<array<class-string>>

--- a/tests/Unit/Application/DomainEventDispatching/DeferredDispatcherTest.php
+++ b/tests/Unit/Application/DomainEventDispatching/DeferredDispatcherTest.php
@@ -21,7 +21,7 @@ use CloudCreativity\Modules\Contracts\Toolkit\Pipeline\PipeContainer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class DeferredDispatcherTest extends TestCase
+final class DeferredDispatcherTest extends TestCase
 {
     private ListenerContainer&MockObject $listeners;
 
@@ -36,10 +36,10 @@ class DeferredDispatcherTest extends TestCase
     {
         parent::setUp();
 
-        $this->dispatcher = new DeferredDispatcher(
+        $this->dispatcher = new class (
             listeners: $this->listeners = $this->createMock(ListenerContainer::class),
             middleware: $this->middleware = $this->createMock(PipeContainer::class),
-        );
+        ) extends DeferredDispatcher {};
     }
 
     public function testItDispatchesImmediately(): void
@@ -108,7 +108,7 @@ class DeferredDispatcherTest extends TestCase
     public function testItFlushesDeferredEvents(): void
     {
         $sequence = [];
-        $event1 = new TestDomainEvent();
+        $event1 = new class () extends TestDomainEvent {};
         $event2 = $this->createMock(DomainEvent::class);
 
         $listener1 = $this->createMock(TestListener::class);
@@ -179,7 +179,7 @@ class DeferredDispatcherTest extends TestCase
     public function testItFlushesDeferredEventsIncludingEventsDispatchedByListeners(): void
     {
         $sequence = [];
-        $event1 = new TestDomainEvent();
+        $event1 = new class () extends TestDomainEvent {};
         $event2 = $this->createMock(DomainEvent::class);
 
         $listener1 = $this->createMock(TestListener::class);
@@ -235,7 +235,7 @@ class DeferredDispatcherTest extends TestCase
     public function testItForgetsDeferredEvents(): void
     {
         $sequence = [];
-        $deferred = new TestDomainEvent();
+        $deferred = new class () extends TestDomainEvent {};
         $immediate = new TestImmediateDomainEvent();
 
         $listener1 = $this->createMock(TestListener::class);
@@ -296,7 +296,7 @@ class DeferredDispatcherTest extends TestCase
     public function testItForgetsDeferredEventsAfterException(): void
     {
         $sequence = [];
-        $event1 = new TestDomainEvent();
+        $event1 = new class () extends TestDomainEvent {};
         $event2 = $this->createMock(DomainEvent::class);
         $expected = new \LogicException('Boom!');
 

--- a/tests/Unit/Application/DomainEventDispatching/DispatcherTest.php
+++ b/tests/Unit/Application/DomainEventDispatching/DispatcherTest.php
@@ -21,7 +21,7 @@ use CloudCreativity\Modules\Contracts\Toolkit\Pipeline\PipeContainer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class DispatcherTest extends TestCase
+final class DispatcherTest extends TestCase
 {
     private ListenerContainer&MockObject $listeners;
 
@@ -33,17 +33,18 @@ class DispatcherTest extends TestCase
     {
         parent::setUp();
 
-        $this->dispatcher = new Dispatcher(
+        $this->dispatcher = new class (
             listeners: $this->listeners = $this->createMock(ListenerContainer::class),
             middleware: $this->middleware = $this->createMock(PipeContainer::class),
-        );
+        ) extends Dispatcher {};
     }
 
     public function testItDispatchesImmediately(): void
     {
         $sequence = [];
         $event1 = new TestImmediateDomainEvent();
-        $event2 = new TestDomainEvent();
+        $event2 = new class () extends TestDomainEvent {};
+        ;
 
         $listener1 = $this->createMock(TestListener::class);
         $listener2 = $this->createMock(TestListener::class);
@@ -110,8 +111,10 @@ class DispatcherTest extends TestCase
 
     public function testItDispatchesThroughMiddleware(): void
     {
-        $event1 = new TestDomainEvent();
-        $event2 = new TestDomainEvent();
+        $event1 = new class () extends TestDomainEvent {};
+        ;
+        $event2 = new class () extends TestDomainEvent {};
+        ;
         $event3 = new TestImmediateDomainEvent();
 
         $a = function ($actual, Closure $next) use ($event1, $event2): DomainEvent {

--- a/tests/Unit/Application/DomainEventDispatching/ListenerContainerTest.php
+++ b/tests/Unit/Application/DomainEventDispatching/ListenerContainerTest.php
@@ -15,14 +15,14 @@ namespace CloudCreativity\Modules\Tests\Unit\Application\DomainEventDispatching;
 use CloudCreativity\Modules\Application\DomainEventDispatching\ListenerContainer;
 use PHPUnit\Framework\TestCase;
 
-class ListenerContainerTest extends TestCase
+final class ListenerContainerTest extends TestCase
 {
     public function testItCreatesListener(): void
     {
         $container = new ListenerContainer();
-        $listener = new TestListener();
+        $listener = new class () extends TestListener {};
 
-        $container->bind('bar', fn () => new TestListener());
+        $container->bind('bar', fn () => new class () extends TestListener {});
         $container->bind('foo', fn () => $listener);
 
         $this->assertSame($listener, $container->get('foo'));

--- a/tests/Unit/Application/DomainEventDispatching/Middleware/LogDomainEventDispatchTest.php
+++ b/tests/Unit/Application/DomainEventDispatching/Middleware/LogDomainEventDispatchTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
-class LogDomainEventDispatchTest extends TestCase
+final class LogDomainEventDispatchTest extends TestCase
 {
     /**
      * @var LoggerInterface&MockObject

--- a/tests/Unit/Application/DomainEventDispatching/TestDomainEvent.php
+++ b/tests/Unit/Application/DomainEventDispatching/TestDomainEvent.php
@@ -15,7 +15,7 @@ namespace CloudCreativity\Modules\Tests\Unit\Application\DomainEventDispatching;
 use CloudCreativity\Modules\Contracts\Domain\Events\DomainEvent;
 use DateTimeImmutable;
 
-class TestDomainEvent implements DomainEvent
+abstract class TestDomainEvent implements DomainEvent
 {
     public function getOccurredAt(): DateTimeImmutable
     {

--- a/tests/Unit/Application/DomainEventDispatching/TestImmediateDomainEvent.php
+++ b/tests/Unit/Application/DomainEventDispatching/TestImmediateDomainEvent.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Contracts\Domain\Events\DomainEvent;
 use CloudCreativity\Modules\Contracts\Domain\Events\OccursImmediately;
 use DateTimeImmutable;
 
-class TestImmediateDomainEvent implements DomainEvent, OccursImmediately
+final class TestImmediateDomainEvent implements DomainEvent, OccursImmediately
 {
     public function getOccurredAt(): DateTimeImmutable
     {

--- a/tests/Unit/Application/DomainEventDispatching/TestListener.php
+++ b/tests/Unit/Application/DomainEventDispatching/TestListener.php
@@ -14,7 +14,7 @@ namespace CloudCreativity\Modules\Tests\Unit\Application\DomainEventDispatching;
 
 use CloudCreativity\Modules\Contracts\Domain\Events\DomainEvent;
 
-class TestListener
+abstract class TestListener
 {
     /**
      * Handle the event.

--- a/tests/Unit/Application/DomainEventDispatching/TestListenerAfterCommit.php
+++ b/tests/Unit/Application/DomainEventDispatching/TestListenerAfterCommit.php
@@ -15,7 +15,7 @@ namespace CloudCreativity\Modules\Tests\Unit\Application\DomainEventDispatching;
 use CloudCreativity\Modules\Contracts\Application\UnitOfWork\DispatchAfterCommit;
 use CloudCreativity\Modules\Contracts\Domain\Events\DomainEvent;
 
-class TestListenerAfterCommit implements DispatchAfterCommit
+abstract class TestListenerAfterCommit implements DispatchAfterCommit
 {
     /**
      * Handle the event.

--- a/tests/Unit/Application/DomainEventDispatching/TestListenerBeforeCommit.php
+++ b/tests/Unit/Application/DomainEventDispatching/TestListenerBeforeCommit.php
@@ -15,7 +15,7 @@ namespace CloudCreativity\Modules\Tests\Unit\Application\DomainEventDispatching;
 use CloudCreativity\Modules\Contracts\Application\UnitOfWork\DispatchBeforeCommit;
 use CloudCreativity\Modules\Contracts\Domain\Events\DomainEvent;
 
-class TestListenerBeforeCommit implements DispatchBeforeCommit
+abstract class TestListenerBeforeCommit implements DispatchBeforeCommit
 {
     /**
      * Handle the event.

--- a/tests/Unit/Application/DomainEventDispatching/UnitOfWorkAwareDispatcherTest.php
+++ b/tests/Unit/Application/DomainEventDispatching/UnitOfWorkAwareDispatcherTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class UnitOfWorkAwareDispatcherTest extends TestCase
+final class UnitOfWorkAwareDispatcherTest extends TestCase
 {
     private ListenerContainer&MockObject $listeners;
 
@@ -42,11 +42,11 @@ class UnitOfWorkAwareDispatcherTest extends TestCase
     {
         parent::setUp();
 
-        $this->dispatcher = new UnitOfWorkAwareDispatcher(
+        $this->dispatcher = new class (
             unitOfWorkManager: $this->unitOfWorkManager = $this->createMock(UnitOfWorkManager::class),
             listeners: $this->listeners = $this->createMock(ListenerContainer::class),
             middleware: $this->middleware = $this->createMock(PipeContainer::class),
-        );
+        ) extends UnitOfWorkAwareDispatcher {};
     }
 
     public function testItDispatchesImmediately(): void
@@ -179,7 +179,7 @@ class UnitOfWorkAwareDispatcherTest extends TestCase
     #[Depends('testItDoesNotDispatchImmediately')]
     public function testItDispatchesEventInBeforeCommitCallback(): void
     {
-        $event = new TestDomainEvent();
+        $event = new class () extends TestDomainEvent {};
 
         $listener1 = $this->createMock(TestListener::class);
         $listener2 = $this->createMock(TestListener::class);

--- a/tests/Unit/Application/InboundEventBus/EventHandlerContainerTest.php
+++ b/tests/Unit/Application/InboundEventBus/EventHandlerContainerTest.php
@@ -19,11 +19,11 @@ use CloudCreativity\Modules\Tests\Unit\Infrastructure\OutboundEventBus\TestOutbo
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-class EventHandlerContainerTest extends TestCase
+final class EventHandlerContainerTest extends TestCase
 {
     public function testItHasHandlerBindings(): void
     {
-        $a = new TestEventHandler();
+        $a = new class () extends TestEventHandler {};
         $b = $this->createStub(TestEventHandler::class);
 
         $container = new EventHandlerContainer();
@@ -36,7 +36,7 @@ class EventHandlerContainerTest extends TestCase
 
     public function testItUsesPsrContainer(): void
     {
-        $a = new TestEventHandler();
+        $a = new class () extends TestEventHandler {};
         $b = $this->createStub(TestEventHandler::class);
 
         $psrContainer = $this->createMock(ContainerInterface::class);
@@ -59,7 +59,7 @@ class EventHandlerContainerTest extends TestCase
 
     public function testItHasBoundDefaultHandler(): void
     {
-        $a = new TestEventHandler();
+        $a = new class () extends TestEventHandler {};
         $b = $this->createStub(TestEventHandler::class);
 
         $container = new EventHandlerContainer(default: fn () => $b);
@@ -71,7 +71,7 @@ class EventHandlerContainerTest extends TestCase
 
     public function testItHasDefaultHandlerInPsrContainer(): void
     {
-        $a = new TestEventHandler();
+        $a = new class () extends TestEventHandler {};
         $b = $this->createStub(TestEventHandler::class);
 
         $psrContainer = $this->createMock(ContainerInterface::class);
@@ -92,7 +92,7 @@ class EventHandlerContainerTest extends TestCase
     public function testItDoesNotHaveHandler(): void
     {
         $container = new EventHandlerContainer();
-        $container->bind(TestInboundEvent::class, fn () => new TestEventHandler());
+        $container->bind(TestInboundEvent::class, fn () => new class () extends TestEventHandler {});
 
         $this->expectException(BusException::class);
         $this->expectExceptionMessage(

--- a/tests/Unit/Application/InboundEventBus/EventHandlerTest.php
+++ b/tests/Unit/Application/InboundEventBus/EventHandlerTest.php
@@ -15,7 +15,7 @@ namespace CloudCreativity\Modules\Tests\Unit\Application\InboundEventBus;
 use CloudCreativity\Modules\Bus\EventHandler;
 use PHPUnit\Framework\TestCase;
 
-class EventHandlerTest extends TestCase
+final class EventHandlerTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Application/InboundEventBus/InboundEventDispatcherTest.php
+++ b/tests/Unit/Application/InboundEventBus/InboundEventDispatcherTest.php
@@ -20,7 +20,7 @@ use CloudCreativity\Modules\Contracts\Toolkit\Pipeline\PipeContainer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class InboundEventDispatcherTest extends TestCase
+final class InboundEventDispatcherTest extends TestCase
 {
     private EventHandlerContainer&MockObject $handlers;
 
@@ -37,10 +37,10 @@ class InboundEventDispatcherTest extends TestCase
     {
         parent::setUp();
 
-        $this->dispatcher = new InboundEventDispatcher(
+        $this->dispatcher = new class (
             handlers: $this->handlers = $this->createMock(EventHandlerContainer::class),
             middleware: $this->middleware = $this->createMock(PipeContainer::class),
-        );
+        ) extends InboundEventDispatcher {};
     }
 
     protected function tearDown(): void

--- a/tests/Unit/Application/InboundEventBus/Middleware/SetupBeforeEventTest.php
+++ b/tests/Unit/Application/InboundEventBus/Middleware/SetupBeforeEventTest.php
@@ -19,7 +19,7 @@ use CloudCreativity\Modules\Toolkit\Result\Result;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-class SetupBeforeEventTest extends TestCase
+final class SetupBeforeEventTest extends TestCase
 {
     /**
      * @var array<string>

--- a/tests/Unit/Application/InboundEventBus/Middleware/TearDownAfterEventTest.php
+++ b/tests/Unit/Application/InboundEventBus/Middleware/TearDownAfterEventTest.php
@@ -17,7 +17,7 @@ use CloudCreativity\Modules\Contracts\Messaging\IntegrationEvent;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-class TearDownAfterEventTest extends TestCase
+final class TearDownAfterEventTest extends TestCase
 {
     public function testItInvokesCallbackAfterSuccess(): void
     {

--- a/tests/Unit/Application/InboundEventBus/SwallowInboundEventTest.php
+++ b/tests/Unit/Application/InboundEventBus/SwallowInboundEventTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
-class SwallowInboundEventTest extends TestCase
+final class SwallowInboundEventTest extends TestCase
 {
     public function testItDoesNothing(): void
     {

--- a/tests/Unit/Application/InboundEventBus/TestEventHandler.php
+++ b/tests/Unit/Application/InboundEventBus/TestEventHandler.php
@@ -14,7 +14,7 @@ namespace CloudCreativity\Modules\Tests\Unit\Application\InboundEventBus;
 
 use CloudCreativity\Modules\Contracts\Bus\DispatchThroughMiddleware;
 
-class TestEventHandler implements DispatchThroughMiddleware
+abstract class TestEventHandler implements DispatchThroughMiddleware
 {
     public function handle(TestInboundEvent $command): void
     {

--- a/tests/Unit/Application/InboundEventBus/TestInboundEvent.php
+++ b/tests/Unit/Application/InboundEventBus/TestInboundEvent.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Contracts\Messaging\IntegrationEvent;
 use CloudCreativity\Modules\Toolkit\Identifiers\UuidV4;
 use DateTimeImmutable;
 
-class TestInboundEvent implements IntegrationEvent
+final class TestInboundEvent implements IntegrationEvent
 {
     public function getUuid(): UuidV4
     {

--- a/tests/Unit/Application/UnitOfWork/UnitOfWorkManagerTest.php
+++ b/tests/Unit/Application/UnitOfWork/UnitOfWorkManagerTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-class UnitOfWorkManagerTest extends TestCase
+final class UnitOfWorkManagerTest extends TestCase
 {
     private MockObject&UnitOfWork $unitOfWork;
 

--- a/tests/Unit/Bus/PsrPipeContainerTest.php
+++ b/tests/Unit/Bus/PsrPipeContainerTest.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Bus\PsrPipeContainer;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-class PsrPipeContainerTest extends TestCase
+final class PsrPipeContainerTest extends TestCase
 {
     public function testItResolvesBoundPipes(): void
     {

--- a/tests/Unit/Domain/EntityTest.php
+++ b/tests/Unit/Domain/EntityTest.php
@@ -19,7 +19,7 @@ use CloudCreativity\Modules\Toolkit\Identifiers\Guid;
 use CloudCreativity\Modules\Toolkit\Identifiers\IntegerId;
 use PHPUnit\Framework\TestCase;
 
-class EntityTest extends TestCase
+final class EntityTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Domain/EntityWithNullableGuidTest.php
+++ b/tests/Unit/Domain/EntityWithNullableGuidTest.php
@@ -19,7 +19,7 @@ use CloudCreativity\Modules\Toolkit\Identifiers\Guid;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
-class EntityWithNullableGuidTest extends TestCase
+final class EntityWithNullableGuidTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Domain/IdentifierOrEntityTest.php
+++ b/tests/Unit/Domain/IdentifierOrEntityTest.php
@@ -17,7 +17,7 @@ use CloudCreativity\Modules\Domain\IdentifierOrEntity;
 use CloudCreativity\Modules\Toolkit\Identifiers\Guid;
 use PHPUnit\Framework\TestCase;
 
-class IdentifierOrEntityTest extends TestCase
+final class IdentifierOrEntityTest extends TestCase
 {
     public function testItIsAGuid(): void
     {

--- a/tests/Unit/Domain/TestEntityWithNullableId.php
+++ b/tests/Unit/Domain/TestEntityWithNullableId.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Contracts\Domain\Entity;
 use CloudCreativity\Modules\Contracts\Toolkit\Identifiers\Identifier;
 use CloudCreativity\Modules\Domain\IsEntityWithNullableId;
 
-class TestEntityWithNullableId implements Entity
+final class TestEntityWithNullableId implements Entity
 {
     use IsEntityWithNullableId;
 

--- a/tests/Unit/Infrastructure/ExceptionReporter/PsrLogExceptionReporterTest.php
+++ b/tests/Unit/Infrastructure/ExceptionReporter/PsrLogExceptionReporterTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
-class PsrLogExceptionReporterTest extends TestCase
+final class PsrLogExceptionReporterTest extends TestCase
 {
     private LoggerInterface&MockObject $logger;
 

--- a/tests/Unit/Infrastructure/InfrastructureExceptionTest.php
+++ b/tests/Unit/Infrastructure/InfrastructureExceptionTest.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Infrastructure\InfrastructureException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-class InfrastructureExceptionTest extends TestCase
+final class InfrastructureExceptionTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Infrastructure/OutboundEventBus/ClosurePublisherTest.php
+++ b/tests/Unit/Infrastructure/OutboundEventBus/ClosurePublisherTest.php
@@ -18,7 +18,7 @@ use CloudCreativity\Modules\Infrastructure\OutboundEventBus\ClosurePublisher;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-class ClosurePublisherTest extends TestCase
+final class ClosurePublisherTest extends TestCase
 {
     /**
      * @var array<IntegrationEvent>
@@ -119,7 +119,7 @@ class ClosurePublisherTest extends TestCase
 
     public function testWithAlternativeHandlers(): void
     {
-        $expected = new TestOutboundEvent();
+        $expected = new class () extends TestOutboundEvent {};
         $stub = $this->createStub(IntegrationEvent::class);
         $actual = null;
 
@@ -130,7 +130,7 @@ class ClosurePublisherTest extends TestCase
         });
 
         $publisher->bind(
-            TestOutboundEvent::class,
+            $expected::class,
             function (TestOutboundEvent $in) use (&$actual) {
                 $actual = $in;
             },
@@ -144,11 +144,11 @@ class ClosurePublisherTest extends TestCase
 
     private function createPublisher(ContainerInterface|IPipeContainer|null $middleware = null): ClosurePublisher
     {
-        return new ClosurePublisher(
+        return new class (
             function (IntegrationEvent $event): void {
                 $this->actual[] = $event;
             },
             $middleware,
-        );
+        ) extends ClosurePublisher {};
     }
 }

--- a/tests/Unit/Infrastructure/OutboundEventBus/ComponentPublisherTest.php
+++ b/tests/Unit/Infrastructure/OutboundEventBus/ComponentPublisherTest.php
@@ -20,7 +20,7 @@ use CloudCreativity\Modules\Infrastructure\OutboundEventBus\ComponentPublisher;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class ComponentPublisherTest extends TestCase
+final class ComponentPublisherTest extends TestCase
 {
     /**
      * @var MockObject&PublisherHandlerContainer
@@ -40,10 +40,10 @@ class ComponentPublisherTest extends TestCase
     {
         parent::setUp();
 
-        $this->publisher = new ComponentPublisher(
+        $this->publisher = new class (
             handlers: $this->handlers = $this->createMock(PublisherHandlerContainer::class),
             middleware: $this->middleware = $this->createMock(PipeContainer::class),
-        );
+        ) extends ComponentPublisher {};
     }
 
     protected function tearDown(): void
@@ -54,7 +54,7 @@ class ComponentPublisherTest extends TestCase
 
     public function testPublish(): void
     {
-        $event = new TestOutboundEvent();
+        $event = new class () extends TestOutboundEvent {};
 
         $this->handlers
             ->expects($this->once())
@@ -72,9 +72,9 @@ class ComponentPublisherTest extends TestCase
 
     public function testPublishWithMiddleware(): void
     {
-        $event1 = new TestOutboundEvent();
-        $event2 = new TestOutboundEvent();
-        $event3 = new TestOutboundEvent();
+        $event1 = new class () extends TestOutboundEvent {};
+        $event2 = new class () extends TestOutboundEvent {};
+        $event3 = new class () extends TestOutboundEvent {};
 
         $middleware1 = function ($actual, Closure $next) use ($event1, $event2): void {
             $this->assertSame($event1, $actual);
@@ -106,7 +106,7 @@ class ComponentPublisherTest extends TestCase
         $this->handlers
             ->expects($this->once())
             ->method('get')
-            ->with($event1::class)
+            ->with($event3::class)
             ->willReturnCallback(function () use ($handler) {
                 $this->assertSame(['before1', 'before2'], $this->sequence);
                 return $handler;

--- a/tests/Unit/Infrastructure/OutboundEventBus/PublisherHandlerContainerTest.php
+++ b/tests/Unit/Infrastructure/OutboundEventBus/PublisherHandlerContainerTest.php
@@ -18,11 +18,11 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
 
-class PublisherHandlerContainerTest extends TestCase
+final class PublisherHandlerContainerTest extends TestCase
 {
     public function testItPublishesViaBindingsWithoutDefaultHandler(): void
     {
-        $a = new TestPublisher();
+        $a = new class () extends TestPublisher {};
         $b = $this->createStub(TestPublisher::class);
 
         $event1 = new class () extends TestOutboundEvent {};
@@ -44,7 +44,7 @@ class PublisherHandlerContainerTest extends TestCase
 
     public function testItPublishesViaBindingsWithDefaultHandler(): void
     {
-        $a = new TestPublisher();
+        $a = new class () extends TestPublisher {};
         $b = $this->createStub(TestPublisher::class);
 
         $event1 = new class () extends TestOutboundEvent {};
@@ -61,7 +61,7 @@ class PublisherHandlerContainerTest extends TestCase
 
     public function testItPublishesViaPsrContainerWithoutDefaultHandler(): void
     {
-        $a = new TestPublisher();
+        $a = new class () extends TestPublisher {};
         $b = $this->createStub(TestPublisher::class);
 
         $event1 = new class () extends TestOutboundEvent {};
@@ -93,7 +93,7 @@ class PublisherHandlerContainerTest extends TestCase
 
     public function testItPublishesViaPsrContainerWithDefaultHandler(): void
     {
-        $a = new TestPublisher();
+        $a = new class () extends TestPublisher {};
         $b = $this->createStub(TestPublisher::class);
 
         $event1 = new class () extends TestOutboundEvent {};

--- a/tests/Unit/Infrastructure/OutboundEventBus/PublisherHandlerTest.php
+++ b/tests/Unit/Infrastructure/OutboundEventBus/PublisherHandlerTest.php
@@ -16,11 +16,11 @@ use CloudCreativity\Modules\Contracts\Infrastructure\OutboundEventBus\PublisherH
 use CloudCreativity\Modules\Infrastructure\OutboundEventBus\PublisherHandler;
 use PHPUnit\Framework\TestCase;
 
-class PublisherHandlerTest extends TestCase
+final class PublisherHandlerTest extends TestCase
 {
     public function test(): void
     {
-        $event = new TestOutboundEvent();
+        $event = new class () extends TestOutboundEvent {};
         $innerHandler = $this->createMock(TestPublisher::class);
 
         $innerHandler

--- a/tests/Unit/Infrastructure/OutboundEventBus/TestOutboundEvent.php
+++ b/tests/Unit/Infrastructure/OutboundEventBus/TestOutboundEvent.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Contracts\Messaging\IntegrationEvent;
 use CloudCreativity\Modules\Toolkit\Identifiers\UuidV4;
 use DateTimeImmutable;
 
-class TestOutboundEvent implements IntegrationEvent
+abstract class TestOutboundEvent implements IntegrationEvent
 {
     public readonly UuidV4 $uuid;
 

--- a/tests/Unit/Infrastructure/OutboundEventBus/TestPublisher.php
+++ b/tests/Unit/Infrastructure/OutboundEventBus/TestPublisher.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\OutboundEventBus;
 
-class TestPublisher
+abstract class TestPublisher
 {
     /**
      * Publish the integration event.

--- a/tests/Unit/Infrastructure/Queue/ClosureQueueTest.php
+++ b/tests/Unit/Infrastructure/Queue/ClosureQueueTest.php
@@ -19,7 +19,7 @@ use CloudCreativity\Modules\Tests\Unit\Application\Bus\TestCommand;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class ClosureQueueTest extends TestCase
+final class ClosureQueueTest extends TestCase
 {
     private MockObject&PipeContainer $middleware;
 
@@ -34,12 +34,12 @@ class ClosureQueueTest extends TestCase
     {
         parent::setUp();
 
-        $this->queue = new ClosureQueue(
+        $this->queue = new class (
             function (Command $command): void {
                 $this->actual[] = $command;
             },
             $this->middleware = $this->createMock(PipeContainer::class),
-        );
+        ) extends ClosureQueue {};
     }
 
     protected function tearDown(): void

--- a/tests/Unit/Infrastructure/Queue/ComponentQueueTest.php
+++ b/tests/Unit/Infrastructure/Queue/ComponentQueueTest.php
@@ -20,7 +20,7 @@ use CloudCreativity\Modules\Infrastructure\Queue\ComponentQueue;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class ComponentQueueTest extends TestCase
+final class ComponentQueueTest extends TestCase
 {
     private EnqueuerContainer&MockObject $enqueuers;
 
@@ -37,10 +37,10 @@ class ComponentQueueTest extends TestCase
     {
         parent::setUp();
 
-        $this->queue = new ComponentQueue(
+        $this->queue = new class (
             enqueuers: $this->enqueuers = $this->createMock(EnqueuerContainer::class),
             middleware: $this->middleware = $this->createMock(PipeContainer::class),
-        );
+        ) extends ComponentQueue {};
     }
 
     protected function tearDown(): void

--- a/tests/Unit/Infrastructure/Queue/EnqueuerContainerTest.php
+++ b/tests/Unit/Infrastructure/Queue/EnqueuerContainerTest.php
@@ -19,14 +19,14 @@ use CloudCreativity\Modules\Tests\Unit\Application\Bus\TestCommand;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-class EnqueuerContainerTest extends TestCase
+final class EnqueuerContainerTest extends TestCase
 {
     public function testItUsesBindings(): void
     {
         $command1 = new class () implements Command {};
         $command2 = new class () implements Command {};
 
-        $a = new TestEnqueuer();
+        $a = new class () extends TestEnqueuer {};
         $b = $this->createStub(TestEnqueuer::class);
         $default = $this->createStub(TestEnqueuer::class);
 
@@ -44,7 +44,7 @@ class EnqueuerContainerTest extends TestCase
         $command1 = new class () implements Command {};
         $command2 = new class () implements Command {};
 
-        $a = new TestEnqueuer();
+        $a = new class () extends TestEnqueuer {};
         $b = $this->createStub(TestEnqueuer::class);
         $default = $this->createStub(TestEnqueuer::class);
 

--- a/tests/Unit/Infrastructure/Queue/EnqueuerTest.php
+++ b/tests/Unit/Infrastructure/Queue/EnqueuerTest.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Contracts\Messaging\Command;
 use CloudCreativity\Modules\Infrastructure\Queue\Enqueuer;
 use PHPUnit\Framework\TestCase;
 
-class EnqueuerTest extends TestCase
+final class EnqueuerTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Infrastructure/Queue/TestEnqueuer.php
+++ b/tests/Unit/Infrastructure/Queue/TestEnqueuer.php
@@ -14,7 +14,7 @@ namespace CloudCreativity\Modules\Tests\Unit\Infrastructure\Queue;
 
 use CloudCreativity\Modules\Contracts\Messaging\Command;
 
-class TestEnqueuer
+abstract class TestEnqueuer
 {
     public function push(Command $command): void
     {

--- a/tests/Unit/Testing/FakeDomainEventDispatcherTest.php
+++ b/tests/Unit/Testing/FakeDomainEventDispatcherTest.php
@@ -18,11 +18,11 @@ use CloudCreativity\Modules\Testing\FakeDomainEventDispatcher;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 
-class FakeDomainEventDispatcherTest extends TestCase
+final class FakeDomainEventDispatcherTest extends TestCase
 {
     public function testItPublishesEvents(): void
     {
-        $dispatcher = new FakeDomainEventDispatcher();
+        $dispatcher = new class () extends FakeDomainEventDispatcher {};
 
         $event1 = $this->createMock(DomainEvent::class);
         $event2 = $this->createMock(DomainEvent::class);
@@ -42,7 +42,7 @@ class FakeDomainEventDispatcherTest extends TestCase
 
     public function testItReturnsSoleEvent(): void
     {
-        $dispatcher = new FakeDomainEventDispatcher();
+        $dispatcher = new class () extends FakeDomainEventDispatcher {};
         $event = $this->createMock(DomainEvent::class);
 
         $dispatcher->dispatch($event);
@@ -52,7 +52,7 @@ class FakeDomainEventDispatcherTest extends TestCase
 
     public function testItThrowsExceptionIfNoEvents(): void
     {
-        $dispatcher = new FakeDomainEventDispatcher();
+        $dispatcher = new class () extends FakeDomainEventDispatcher {};
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Expected one event to be dispatched but there are 0 events.');
@@ -62,7 +62,7 @@ class FakeDomainEventDispatcherTest extends TestCase
 
     public function testItThrowsExceptionIfMultipleEvents(): void
     {
-        $dispatcher = new FakeDomainEventDispatcher();
+        $dispatcher = new class () extends FakeDomainEventDispatcher {};
         $event1 = $this->createMock(DomainEvent::class);
         $event2 = $this->createMock(DomainEvent::class);
 
@@ -73,12 +73,5 @@ class FakeDomainEventDispatcherTest extends TestCase
         $this->expectExceptionMessage('Expected one event to be dispatched but there are 2 events.');
 
         $dispatcher->sole();
-    }
-
-    public function testItCanBeExtended(): void
-    {
-        $dispatcher = new class () extends FakeDomainEventDispatcher {};
-        $dispatcher->dispatch($this->createMock(DomainEvent::class));
-        $this->assertCount(1, $dispatcher->events);
     }
 }

--- a/tests/Unit/Testing/FakeExceptionReporterTest.php
+++ b/tests/Unit/Testing/FakeExceptionReporterTest.php
@@ -18,7 +18,7 @@ use LogicException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-class FakeExceptionReporterTest extends TestCase
+final class FakeExceptionReporterTest extends TestCase
 {
     public function testItReportsExceptions(): void
     {

--- a/tests/Unit/Testing/FakeOutboundEventPublisherTest.php
+++ b/tests/Unit/Testing/FakeOutboundEventPublisherTest.php
@@ -18,11 +18,11 @@ use CloudCreativity\Modules\Testing\FakeOutboundEventPublisher;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 
-class FakeOutboundEventPublisherTest extends TestCase
+final class FakeOutboundEventPublisherTest extends TestCase
 {
     public function testItPublishesEvents(): void
     {
-        $publisher = new FakeOutboundEventPublisher();
+        $publisher = new class () extends FakeOutboundEventPublisher {};
 
         $event1 = $this->createMock(IntegrationEvent::class);
         $event2 = $this->createMock(IntegrationEvent::class);
@@ -40,7 +40,7 @@ class FakeOutboundEventPublisherTest extends TestCase
 
     public function testItReturnsSoleEvent(): void
     {
-        $publisher = new FakeOutboundEventPublisher();
+        $publisher = new class () extends FakeOutboundEventPublisher {};
         $event = $this->createMock(IntegrationEvent::class);
 
         $publisher->publish($event);
@@ -50,7 +50,7 @@ class FakeOutboundEventPublisherTest extends TestCase
 
     public function testItThrowsExceptionIfNoEvents(): void
     {
-        $publisher = new FakeOutboundEventPublisher();
+        $publisher = new class () extends FakeOutboundEventPublisher {};
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Expected one event to be published but there are 0 events.');
@@ -60,7 +60,7 @@ class FakeOutboundEventPublisherTest extends TestCase
 
     public function testItThrowsExceptionIfMultipleEvents(): void
     {
-        $publisher = new FakeOutboundEventPublisher();
+        $publisher = new class () extends FakeOutboundEventPublisher {};
         $event1 = $this->createMock(IntegrationEvent::class);
         $event2 = $this->createMock(IntegrationEvent::class);
 
@@ -71,12 +71,5 @@ class FakeOutboundEventPublisherTest extends TestCase
         $this->expectExceptionMessage('Expected one event to be published but there are 2 events.');
 
         $publisher->sole();
-    }
-
-    public function testItCanBeExtended(): void
-    {
-        $publisher = new class () extends FakeOutboundEventPublisher {};
-        $publisher->publish($this->createMock(IntegrationEvent::class));
-        $this->assertCount(1, $publisher->events);
     }
 }

--- a/tests/Unit/Testing/FakeQueueTest.php
+++ b/tests/Unit/Testing/FakeQueueTest.php
@@ -18,11 +18,11 @@ use CloudCreativity\Modules\Testing\FakeQueue;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 
-class FakeQueueTest extends TestCase
+final class FakeQueueTest extends TestCase
 {
     public function testItQueuesCommands(): void
     {
-        $queue = new FakeQueue();
+        $queue = new class () extends FakeQueue {};
         $queue->push($command1 = $this->createMock(Command::class));
         $queue->push($command2 = $this->createMock(Command::class));
 
@@ -36,7 +36,7 @@ class FakeQueueTest extends TestCase
 
     public function testItHasSoleCommand(): void
     {
-        $queue = new FakeQueue();
+        $queue = new class () extends FakeQueue {};
         $queue->push($command = $this->createMock(Command::class));
 
         $this->assertSame($command, $queue->sole());
@@ -47,7 +47,7 @@ class FakeQueueTest extends TestCase
         $this->expectExceptionMessage('Expected one command in the queue but there are 0 commands.');
         $this->expectException(LogicException::class);
 
-        $queue = new FakeQueue();
+        $queue = new class () extends FakeQueue {};
         $queue->sole();
     }
 
@@ -56,17 +56,9 @@ class FakeQueueTest extends TestCase
         $this->expectExceptionMessage('Expected one command in the queue but there are 2 commands.');
         $this->expectException(LogicException::class);
 
-        $queue = new FakeQueue();
+        $queue = new class () extends FakeQueue {};
         $queue->push($this->createMock(Command::class));
         $queue->push($this->createMock(Command::class));
         $queue->sole();
-    }
-
-    public function testItCanBeExtended(): void
-    {
-        $queue = new class () extends FakeQueue {};
-
-        $queue->push($command = $this->createMock(Command::class));
-        $this->assertSame([$command], $queue->commands);
     }
 }

--- a/tests/Unit/Testing/FakeUnitOfWorkTest.php
+++ b/tests/Unit/Testing/FakeUnitOfWorkTest.php
@@ -17,7 +17,7 @@ use CloudCreativity\Modules\Testing\FakeUnitOfWork;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-class FakeUnitOfWorkTest extends TestCase
+final class FakeUnitOfWorkTest extends TestCase
 {
     public function testItIsSuccessfulOnFirstAttempt(): void
     {

--- a/tests/Unit/Toolkit/ContractsTest.php
+++ b/tests/Unit/Toolkit/ContractsTest.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Toolkit\ContractException;
 use CloudCreativity\Modules\Toolkit\Contracts;
 use PHPUnit\Framework\TestCase;
 
-class ContractsTest extends TestCase
+final class ContractsTest extends TestCase
 {
     public function testItDoesNotThrowWhenPreconditionIsTrue(): void
     {

--- a/tests/Unit/Toolkit/EnumStringTest.php
+++ b/tests/Unit/Toolkit/EnumStringTest.php
@@ -21,7 +21,7 @@ use UnitEnum;
 
 use function CloudCreativity\Modules\Toolkit\enum_string;
 
-class EnumStringTest extends TestCase
+final class EnumStringTest extends TestCase
 {
     /**
      * @return array<string, array{0: int|string|UnitEnum, 1: string}>

--- a/tests/Unit/Toolkit/EnumValueTest.php
+++ b/tests/Unit/Toolkit/EnumValueTest.php
@@ -21,7 +21,7 @@ use UnitEnum;
 
 use function CloudCreativity\Modules\Toolkit\enum_value;
 
-class EnumValueTest extends TestCase
+final class EnumValueTest extends TestCase
 {
     /**
      * @return array<string, array{0: int|string|UnitEnum, 1: int|string}>

--- a/tests/Unit/Toolkit/Identifiers/GuidTest.php
+++ b/tests/Unit/Toolkit/Identifiers/GuidTest.php
@@ -28,7 +28,7 @@ use Ramsey\Uuid\Uuid as BaseUuid;
 use Ramsey\Uuid\UuidInterface;
 use UnitEnum;
 
-class GuidTest extends TestCase
+final class GuidTest extends TestCase
 {
     /**
      * @return array<string, array<int, mixed>>

--- a/tests/Unit/Toolkit/Identifiers/GuidTypeMapTest.php
+++ b/tests/Unit/Toolkit/Identifiers/GuidTypeMapTest.php
@@ -22,7 +22,7 @@ use CloudCreativity\Modules\Toolkit\Identifiers\Uuid;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
-class GuidTypeMapTest extends TestCase
+final class GuidTypeMapTest extends TestCase
 {
     public function testItReturnsExpectedType(): GuidTypeMap
     {

--- a/tests/Unit/Toolkit/Identifiers/IntegerIdTest.php
+++ b/tests/Unit/Toolkit/Identifiers/IntegerIdTest.php
@@ -22,7 +22,7 @@ use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-class IntegerIdTest extends TestCase
+final class IntegerIdTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Toolkit/Identifiers/PossiblyNumericIdTest.php
+++ b/tests/Unit/Toolkit/Identifiers/PossiblyNumericIdTest.php
@@ -18,7 +18,7 @@ use CloudCreativity\Modules\Toolkit\Identifiers\StringId;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-class PossiblyNumericIdTest extends TestCase
+final class PossiblyNumericIdTest extends TestCase
 {
     /**
      * @return array<array<int, mixed>>

--- a/tests/Unit/Toolkit/Identifiers/StringIdTest.php
+++ b/tests/Unit/Toolkit/Identifiers/StringIdTest.php
@@ -21,7 +21,7 @@ use CloudCreativity\Modules\Toolkit\Identifiers\Uuid;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-class StringIdTest extends TestCase
+final class StringIdTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Toolkit/Identifiers/UuidFactoryTest.php
+++ b/tests/Unit/Toolkit/Identifiers/UuidFactoryTest.php
@@ -27,7 +27,7 @@ use Ramsey\Uuid\Uuid as BaseUuid;
 use Ramsey\Uuid\UuidFactory as BaseUuidFactory;
 use Ramsey\Uuid\UuidFactoryInterface as BaseUuidFactoryInterface;
 
-class UuidFactoryTest extends TestCase
+final class UuidFactoryTest extends TestCase
 {
     private BaseUuidFactory&MockObject $baseFactory;
 

--- a/tests/Unit/Toolkit/Identifiers/UuidTest.php
+++ b/tests/Unit/Toolkit/Identifiers/UuidTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid as RamseyUuid;
 
-class UuidTest extends TestCase
+final class UuidTest extends TestCase
 {
     protected function tearDown(): void
     {

--- a/tests/Unit/Toolkit/Identifiers/UuidV4Test.php
+++ b/tests/Unit/Toolkit/Identifiers/UuidV4Test.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid as RamseyUuid;
 
-class UuidV4Test extends TestCase
+final class UuidV4Test extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Toolkit/Identifiers/UuidV7Test.php
+++ b/tests/Unit/Toolkit/Identifiers/UuidV7Test.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid as RamseyUuid;
 
-class UuidV7Test extends TestCase
+final class UuidV7Test extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Toolkit/Iterables/IsLazyListTest.php
+++ b/tests/Unit/Toolkit/Iterables/IsLazyListTest.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Contracts\Toolkit\Iterables\LazyList;
 use CloudCreativity\Modules\Toolkit\Iterables\IsLazyList;
 use PHPUnit\Framework\TestCase;
 
-class IsLazyListTest extends TestCase
+final class IsLazyListTest extends TestCase
 {
     public function testItIteratesOverList(): void
     {

--- a/tests/Unit/Toolkit/Iterables/IsNonEmptyListTest.php
+++ b/tests/Unit/Toolkit/Iterables/IsNonEmptyListTest.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Contracts\Toolkit\Iterables\NonEmptyList;
 use CloudCreativity\Modules\Toolkit\Iterables\IsNonEmptyList;
 use PHPUnit\Framework\TestCase;
 
-class IsNonEmptyListTest extends TestCase
+final class IsNonEmptyListTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Toolkit/ModuleBasenameTest.php
+++ b/tests/Unit/Toolkit/ModuleBasenameTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
-class ModuleBasenameTest extends TestCase
+final class ModuleBasenameTest extends TestCase
 {
     /**
      * @return array<array<string>>

--- a/tests/Unit/Toolkit/Pipeline/AccumulationProcessorTest.php
+++ b/tests/Unit/Toolkit/Pipeline/AccumulationProcessorTest.php
@@ -15,7 +15,7 @@ namespace CloudCreativity\Modules\Tests\Unit\Toolkit\Pipeline;
 use CloudCreativity\Modules\Toolkit\Pipeline\AccumulationProcessor;
 use PHPUnit\Framework\TestCase;
 
-class AccumulationProcessorTest extends TestCase
+final class AccumulationProcessorTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Toolkit/Pipeline/InterruptibleProcessorTest.php
+++ b/tests/Unit/Toolkit/Pipeline/InterruptibleProcessorTest.php
@@ -15,7 +15,7 @@ namespace CloudCreativity\Modules\Tests\Unit\Toolkit\Pipeline;
 use CloudCreativity\Modules\Toolkit\Pipeline\InterruptibleProcessor;
 use PHPUnit\Framework\TestCase;
 
-class InterruptibleProcessorTest extends TestCase
+final class InterruptibleProcessorTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Toolkit/Pipeline/LazyPipeTest.php
+++ b/tests/Unit/Toolkit/Pipeline/LazyPipeTest.php
@@ -18,7 +18,7 @@ use CloudCreativity\Modules\Toolkit\Pipeline\LazyPipe;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class LazyPipeTest extends TestCase
+final class LazyPipeTest extends TestCase
 {
     /**
      * @var MockObject&PipeContainer

--- a/tests/Unit/Toolkit/Pipeline/MiddlewareProcessorTest.php
+++ b/tests/Unit/Toolkit/Pipeline/MiddlewareProcessorTest.php
@@ -16,7 +16,7 @@ use Closure;
 use CloudCreativity\Modules\Toolkit\Pipeline\MiddlewareProcessor;
 use PHPUnit\Framework\TestCase;
 
-class MiddlewareProcessorTest extends TestCase
+final class MiddlewareProcessorTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Toolkit/Pipeline/PipeContainerTest.php
+++ b/tests/Unit/Toolkit/Pipeline/PipeContainerTest.php
@@ -15,7 +15,7 @@ namespace CloudCreativity\Modules\Tests\Unit\Toolkit\Pipeline;
 use CloudCreativity\Modules\Toolkit\Pipeline\PipeContainer;
 use PHPUnit\Framework\TestCase;
 
-class PipeContainerTest extends TestCase
+final class PipeContainerTest extends TestCase
 {
     public function testItResolvesBoundPipes(): void
     {

--- a/tests/Unit/Toolkit/Pipeline/PipelineBuilderTest.php
+++ b/tests/Unit/Toolkit/Pipeline/PipelineBuilderTest.php
@@ -19,7 +19,7 @@ use CloudCreativity\Modules\Toolkit\Pipeline\Pipeline;
 use CloudCreativity\Modules\Toolkit\Pipeline\PipelineBuilder;
 use PHPUnit\Framework\TestCase;
 
-class PipelineBuilderTest extends TestCase
+final class PipelineBuilderTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Toolkit/Pipeline/PipelineTest.php
+++ b/tests/Unit/Toolkit/Pipeline/PipelineTest.php
@@ -16,7 +16,7 @@ use CloudCreativity\Modules\Contracts\Toolkit\Pipeline\Processor;
 use CloudCreativity\Modules\Toolkit\Pipeline\Pipeline;
 use PHPUnit\Framework\TestCase;
 
-class PipelineTest extends TestCase
+final class PipelineTest extends TestCase
 {
     public function testProcess(): void
     {

--- a/tests/Unit/Toolkit/Pipeline/SimpleProcessorTest.php
+++ b/tests/Unit/Toolkit/Pipeline/SimpleProcessorTest.php
@@ -15,7 +15,7 @@ namespace CloudCreativity\Modules\Tests\Unit\Toolkit\Pipeline;
 use CloudCreativity\Modules\Toolkit\Pipeline\SimpleProcessor;
 use PHPUnit\Framework\TestCase;
 
-class SimpleProcessorTest extends TestCase
+final class SimpleProcessorTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Toolkit/Result/ErrorTest.php
+++ b/tests/Unit/Toolkit/Result/ErrorTest.php
@@ -19,7 +19,7 @@ use CloudCreativity\Modules\Toolkit\ContractException;
 use CloudCreativity\Modules\Toolkit\Result\Error;
 use PHPUnit\Framework\TestCase;
 
-class ErrorTest extends TestCase
+final class ErrorTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Toolkit/Result/FailedResultExceptionTest.php
+++ b/tests/Unit/Toolkit/Result/FailedResultExceptionTest.php
@@ -17,7 +17,7 @@ use CloudCreativity\Modules\Toolkit\Result\FailedResultException;
 use CloudCreativity\Modules\Toolkit\Result\Result;
 use PHPUnit\Framework\TestCase;
 
-class FailedResultExceptionTest extends TestCase
+final class FailedResultExceptionTest extends TestCase
 {
     public function testItFailsWithMessage(): void
     {

--- a/tests/Unit/Toolkit/Result/KeyedSetOfErrorsTest.php
+++ b/tests/Unit/Toolkit/Result/KeyedSetOfErrorsTest.php
@@ -18,7 +18,7 @@ use CloudCreativity\Modules\Toolkit\Result\KeyedSetOfErrors;
 use CloudCreativity\Modules\Toolkit\Result\ListOfErrors;
 use PHPUnit\Framework\TestCase;
 
-class KeyedSetOfErrorsTest extends TestCase
+final class KeyedSetOfErrorsTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Toolkit/Result/ListOfErrorsTest.php
+++ b/tests/Unit/Toolkit/Result/ListOfErrorsTest.php
@@ -21,7 +21,7 @@ use CloudCreativity\Modules\Toolkit\Result\KeyedSetOfErrors;
 use CloudCreativity\Modules\Toolkit\Result\ListOfErrors;
 use PHPUnit\Framework\TestCase;
 
-class ListOfErrorsTest extends TestCase
+final class ListOfErrorsTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Toolkit/Result/MetaTest.php
+++ b/tests/Unit/Toolkit/Result/MetaTest.php
@@ -15,7 +15,7 @@ namespace CloudCreativity\Modules\Tests\Unit\Toolkit\Result;
 use CloudCreativity\Modules\Toolkit\Result\Meta;
 use PHPUnit\Framework\TestCase;
 
-class MetaTest extends TestCase
+final class MetaTest extends TestCase
 {
     public function test(): void
     {

--- a/tests/Unit/Toolkit/Result/ResultTest.php
+++ b/tests/Unit/Toolkit/Result/ResultTest.php
@@ -27,7 +27,7 @@ use UnitEnum;
 
 use function CloudCreativity\Modules\Toolkit\enum_string;
 
-class ResultTest extends TestCase
+final class ResultTest extends TestCase
 {
     public function testOk(): void
     {


### PR DESCRIPTION
This PR enforces `final` classes. This means that all classes (e.g. bus dispatchers) that are intended to be extended (so they can implement the module interface e.g. the specific command bus interface) are now `abstract`.

This should just work with existing implementations. The only potential impact would be the exception classes, which are now `final` - instead there are exception interfaces that should be caught.